### PR TITLE
Remove non public-facing primitives (yet at least), and add missing ones

### DIFF
--- a/pages/primitives/docs/components/collection.mdx
+++ b/pages/primitives/docs/components/collection.mdx
@@ -1,5 +1,0 @@
----
-title: 'Collection'
----
-
-Collection Primitive. Coming soon.

--- a/pages/primitives/docs/components/context-menu.mdx
+++ b/pages/primitives/docs/components/context-menu.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'ContextMenu'
+title: 'Context Menu'
 ---
 
-ContextMenu Primitive. Coming soon.
+Context Menu Primitive. Coming soon.

--- a/pages/primitives/docs/components/context-menu.mdx
+++ b/pages/primitives/docs/components/context-menu.mdx
@@ -1,0 +1,5 @@
+---
+title: 'ContextMenu'
+---
+
+ContextMenu Primitive. Coming soon.

--- a/pages/primitives/docs/components/dismissable-layer.mdx
+++ b/pages/primitives/docs/components/dismissable-layer.mdx
@@ -1,5 +1,0 @@
----
-title: 'Dismissable Layer'
----
-
-Dismissable Layer Primitive. Coming soon.

--- a/pages/primitives/docs/components/dropdown-menu.mdx
+++ b/pages/primitives/docs/components/dropdown-menu.mdx
@@ -1,0 +1,5 @@
+---
+title: 'DropdownMenu'
+---
+
+DropdownMenu Primitive. Coming soon.

--- a/pages/primitives/docs/components/dropdown-menu.mdx
+++ b/pages/primitives/docs/components/dropdown-menu.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'DropdownMenu'
+title: 'Dropdown Menu'
 ---
 
-DropdownMenu Primitive. Coming soon.
+Dropdown Menu Primitive. Coming soon.

--- a/pages/primitives/docs/components/focus-scope.mdx
+++ b/pages/primitives/docs/components/focus-scope.mdx
@@ -1,5 +1,0 @@
----
-title: 'Focus Scope'
----
-
-Focus Scope Primitive. Coming soon.

--- a/pages/primitives/docs/components/menu.mdx
+++ b/pages/primitives/docs/components/menu.mdx
@@ -1,6 +1,0 @@
----
-title: 'Menu'
-status: 'soon'
----
-
-Menu Primitive. Coming soon.

--- a/pages/primitives/docs/components/popper.mdx
+++ b/pages/primitives/docs/components/popper.mdx
@@ -1,5 +1,0 @@
----
-title: 'Popper'
----
-
-Popper Primitive. Coming soon.

--- a/pages/primitives/docs/components/scroll-area.mdx
+++ b/pages/primitives/docs/components/scroll-area.mdx
@@ -1,0 +1,5 @@
+---
+title: 'ScrollArea'
+---
+
+ScrollArea Primitive. Coming soon.

--- a/pages/primitives/docs/components/select.mdx
+++ b/pages/primitives/docs/components/select.mdx
@@ -1,5 +1,0 @@
----
-title: 'Select'
----
-
-Select Primitive. Coming soon.

--- a/pages/primitives/docs/components/select.mdx
+++ b/pages/primitives/docs/components/select.mdx
@@ -1,0 +1,6 @@
+---
+title: 'Select'
+status: 'soon'
+---
+
+Select Primitive. Coming soon.

--- a/pages/primitives/docs/components/switch.mdx
+++ b/pages/primitives/docs/components/switch.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Switch'
+---
+
+Switch Primitive. Coming soon.

--- a/pages/primitives/docs/components/toggle-button.mdx
+++ b/pages/primitives/docs/components/toggle-button.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'ToggleButton'
+title: 'Toggle Button'
 ---
 
-ToggleButton Primitive. Coming soon.
+Toggle Button Primitive. Coming soon.

--- a/pages/primitives/docs/components/toggle-button.mdx
+++ b/pages/primitives/docs/components/toggle-button.mdx
@@ -1,0 +1,5 @@
+---
+title: 'ToggleButton'
+---
+
+ToggleButton Primitive. Coming soon.

--- a/pages/primitives/docs/components/tooltip.mdx
+++ b/pages/primitives/docs/components/tooltip.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Tooltip'
+---
+
+Tooltip Primitive. Coming soon.

--- a/pages/primitives/docs/components/visually-hidden.mdx
+++ b/pages/primitives/docs/components/visually-hidden.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'VisuallyHidden'
+title: 'Visually Hidden'
 ---
 
-VisuallyHidden Primitive. Coming soon.
+Visually Hidden Primitive. Coming soon.

--- a/pages/primitives/docs/components/visually-hidden.mdx
+++ b/pages/primitives/docs/components/visually-hidden.mdx
@@ -1,0 +1,5 @@
+---
+title: 'VisuallyHidden'
+---
+
+VisuallyHidden Primitive. Coming soon.


### PR DESCRIPTION
No need to document these low-level ones for now, they are used within primitives but not really public facing.

Removed:
- `Collection`
- `DismissableLayer`
- `FocusScope`
- `Menu`
- `Popper`

Added:
- `ContextMenu`
- `DropdownMenu`
- `ScrollArea`
- `Switch`
- `ToggleButton`
- `Tooltip`
- `VisuallyHidden`