### PR TITLE
Add focusable region wrapper with allowable overflow

### DIFF
--- a/components/KeyboardTable.tsx
+++ b/components/KeyboardTable.tsx
@@ -1,16 +1,27 @@
 import React from 'react';
 import { Box, Text, Kbd } from '@modulz/design-system';
+import { RegionTable } from './RegionTable';
 
 type KeyboardDef = {
   keys: string[];
   description: React.ReactNode;
 };
 
-export function KeyboardTable({ data }: { data: KeyboardDef[] }) {
+export function KeyboardTable({
+  data,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+}: {
+  data: KeyboardDef[];
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}) {
+  const hasAriaLabel = !!(ariaLabel || ariaLabelledBy);
   return (
-    <Box
-      as="table"
+    <RegionTable
       css={{ width: '100%', textAlign: 'left', borderCollapse: 'collapse', mt: '$2' }}
+      aria-label={hasAriaLabel ? ariaLabel : 'Keyboard Interactions'}
+      aria-labelledby={ariaLabelledBy}
     >
       <thead>
         <tr>
@@ -52,6 +63,6 @@ export function KeyboardTable({ data }: { data: KeyboardDef[] }) {
           </tr>
         ))}
       </tbody>
-    </Box>
+    </RegionTable>
   );
 }

--- a/components/PropsTable.tsx
+++ b/components/PropsTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, IconButton, Text, Code, Popover } from '@modulz/design-system';
 import { CheckIcon, InfoCircledIcon, DividerHorizontalIcon } from '@modulz/radix-icons';
+import { RegionTable } from './RegionTable';
 
 type PropDef = {
   name: string;
@@ -11,9 +12,22 @@ type PropDef = {
   description?: string;
 };
 
-export function PropsTable({ data }: { data: PropDef[] }) {
+export function PropsTable({
+  data,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+}: {
+  data: PropDef[];
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}) {
+  const hasAriaLabel = !!(ariaLabel || ariaLabelledBy);
   return (
-    <Box as="table" css={{ width: '100%', textAlign: 'left', borderCollapse: 'collapse' }}>
+    <RegionTable
+      css={{ width: '100%', textAlign: 'left', borderCollapse: 'collapse' }}
+      aria-label={hasAriaLabel ? ariaLabel : 'Component Props'}
+      aria-labelledby={ariaLabelledBy}
+    >
       <thead>
         <tr>
           <Box as="th" css={{ borderBottom: '1px solid $gray500', py: '$3', pr: '$4' }}>
@@ -142,6 +156,6 @@ export function PropsTable({ data }: { data: PropDef[] }) {
           </tr>
         ))}
       </tbody>
-    </Box>
+    </RegionTable>
   );
 }

--- a/components/RegionTable.tsx
+++ b/components/RegionTable.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, BoxProps, theme as DStheme } from '@modulz/design-system';
+
+export function RegionTable({
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  ...props
+}: BoxProps) {
+  return (
+    <Box
+      as="div"
+      role="region"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      tabIndex={0}
+      css={{
+        overflow: 'auto',
+        '&:focus': {
+          outline: 0,
+          boxShadow: `0 0 0 3px ${DStheme.colors.$gray700}`,
+        },
+      }}
+    >
+      <Box as="table" {...props} />
+    </Box>
+  );
+}


### PR DESCRIPTION
This change mirrors changes I made in the Primitive docs to improve accessibility of tables.
- A table gets a focusable wrapper marked as a `region` with an accessible name
- The wrapper allows for horizontal overflow to better support small screens and zoom settings
- When there is an overflow, the wrapper having focus allows keyboard scrolling to see the parts of the table that are cut off