### PR TITLE
Ignore editor preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# Editor-specific
+.vscode
+.idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}


### PR DESCRIPTION
I think it's generally a good idea to ignore these files, as it's hard to have your own local preferences when we include them. We do already in the primitives repo.

@peduarte calling this to your attention, as it may be important to add back to your local configuration if we're good with taking this out. 