### PR TITLE
Fix scrollbar jank on QuickNav (#64)

### DIFF
--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
+import { RemoveScroll } from 'react-remove-scroll';
 import { MDXProvider } from '@mdx-js/react';
 import {
   Text,
@@ -63,6 +64,14 @@ export default function DocsLayout({ children, frontMatter }: LayoutProps) {
       <ScrollArea>
         <Box
           as="aside"
+          // Components that hide the scrollbar (like Dialog) add padding to
+          // account for the scrollbar gap to avoid layout jank. This does not
+          // work for position: fixed elements. Since we use react-remove-scroll
+          // under the hood for those primitives, we can add this helper class
+          // provided by that lib to deal with that for the QuickNav.
+          // https://github.com/radix-ui/website/issues/64
+          // https://github.com/theKashey/react-remove-scroll#positionfixed-elements
+          className={RemoveScroll.classNames.zeroRight}
           css={{
             display: 'none',
             bp3: {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-live": "^2.2.3",
+    "react-remove-scroll": "^2.4.0",
     "reading-time": "^1.2.1",
     "rehype": "^11.0.0",
     "remark-autolink-headings": "^6.0.1",


### PR DESCRIPTION
Fixes #64 by adding the helper class from [react-remove-scroll](https://github.com/theKashey/react-remove-scroll#positionfixed-elements) designed to deal with `position: fixed` elements when `right` is set to `0`.