### PR TITLE
Fixed typo in alert-dialog name

### DIFF
--- a/pages/primitives/docs/components/alert-dialog.mdx
+++ b/pages/primitives/docs/components/alert-dialog.mdx
@@ -1,6 +1,6 @@
 ---
 title: Alert Dialog
-name: alert-aialog
+name: alert-dialog
 version: 0.0.1
 description: A modal dialog that interrupts the user with important content and expects a response.
 aria: https://www.w3.org/TR/wai-aria-practices-1.2/#alertdialog


### PR DESCRIPTION
Causes 'View Source' hyperlink to 404