### PR TITLE
Tooltip docs: Fix import statement

### DIFF
--- a/pages/primitives/docs/components/tooltip.mdx
+++ b/pages/primitives/docs/components/tooltip.mdx
@@ -29,7 +29,7 @@ npm install @radix-ui/react-tooltip
 Import the components and piece the parts together.
 
 ```jsx
-import * as Tooltip from '@radix-ui/react-switch';
+import * as Tooltip from '@radix-ui/react-tooltip';
 
 export default () => (
   <Tooltip.Root>


### PR DESCRIPTION
This pull request:
- [x] Updates documentation or example code


URL: https://radix-ui.com/primitives/docs/components/tooltip#anatomy

I copy pasted from the example and was confused why it isn't working 😅 

