### PR TITLE
Fix missing Dialog.Root in docs.

### DIFF
--- a/pages/primitives/docs/components/dialog.mdx
+++ b/pages/primitives/docs/components/dialog.mdx
@@ -32,13 +32,13 @@ Import the components and piece the parts together.
 import * as Dialog from '@radix-ui/react-dialog';
 
 export default () => (
-  <Dialog>
+  <Dialog.Root>
     <Dialog.Trigger />
     <Dialog.Overlay />
     <Dialog.Content>
       <Dialog.Close />
     </Dialog.Content>
-  </Dialog>
+  </Dialog.Root>
 );
 ```
 


### PR DESCRIPTION
The default export here isn't working for me. The later docs show a Dialog.Root, which is working. Maybe a change that didn't make its way back into the first example?

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
