### PR TITLE
docs: Update disableOutsidePointerEvents default value

### DIFF
--- a/pages/primitives/docs/components/dropdown-menu.mdx
+++ b/pages/primitives/docs/components/dropdown-menu.mdx
@@ -213,7 +213,7 @@ The component that pops out when the dropdown menu is open.
     {
       name: 'disableOutsidePointerEvents',
       type: 'boolean',
-      default: 'false',
+      default: 'true',
       description: (
         <span>
           When <Code>true</Code>, hover/focus/click interactions will


### PR DESCRIPTION
The documentation did not reflect the [correct default value](https://github.com/radix-ui/primitives/blob/main/packages/react/dropdown-menu/src/DropdownMenu.tsx#L116) for the `disableOutsidePointerEvents` prop. Let me know if I should also change the description to explain what happens if you set it to false, even thou I think it's quite self explanatory.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
