### PR TITLE
Simplify Animation intro copy

### DIFF
--- a/pages/primitives/docs/overview/animation.mdx
+++ b/pages/primitives/docs/overview/animation.mdx
@@ -4,7 +4,7 @@ description: Animate Radix Primitives with CSS keyframes or the JavaScript anima
 navRank: 4
 ---
 
-Animation of Radix Primitives can generally be summed in terms of the `entering` and `exiting` phases of a stateful component. In either case, adding animation to a Primitives component should feel similar to any other component, but there are some caveats noted here in regards to `exiting` animations with JS animation libraries.
+Adding animation to Radix Primitives should feel similar to any other component, but there are some caveats noted here in regards to `exiting` animations with JS animation libraries.
 
 ## Animating with CSS transition and CSS animation
 


### PR DESCRIPTION
Removes a paragraph from the Animation docs. This sentence always threw me off when I read this copy, not entirely sure what it means so I've had a go at simplifying to reduce cognitive load.