### PR TITLE
[Tooltip][Slot] Rename props prefixed with `is`

### DIFF
--- a/pages/primitives/docs/components/tooltip/0.0.1/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.1/index.mdx
@@ -392,16 +392,16 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger
         as={React.forwardRef((props, forwardedRef) =>

--- a/pages/primitives/docs/components/tooltip/0.0.2/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.2/index.mdx
@@ -431,16 +431,16 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger
         as={React.forwardRef((props, forwardedRef) =>

--- a/pages/primitives/docs/components/tooltip/0.0.3/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.3/index.mdx
@@ -431,16 +431,16 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger
         as={React.forwardRef((props, forwardedRef) =>

--- a/pages/primitives/docs/components/tooltip/0.0.4/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.4/index.mdx
@@ -434,16 +434,16 @@ import { Slot } from '@radix-ui/react-slot';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/components/tooltip/0.0.5/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.5/index.mdx
@@ -434,16 +434,16 @@ import { Slot } from '@radix-ui/react-slot';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/components/tooltip/0.0.6/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.6/index.mdx
@@ -434,16 +434,16 @@ import { Slot } from '@radix-ui/react-slot';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/components/tooltip/0.0.7/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.7/index.mdx
@@ -434,16 +434,16 @@ import { Slot } from '@radix-ui/react-slot';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/components/tooltip/0.0.8/index.mdx
+++ b/pages/primitives/docs/components/tooltip/0.0.8/index.mdx
@@ -434,16 +434,16 @@ import { Slot } from '@radix-ui/react-slot';
 export function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/utilities/slot/0.0.1/index.mdx
+++ b/pages/primitives/docs/utilities/slot/0.0.1/index.mdx
@@ -41,16 +41,16 @@ import { Slot } from '@radix-ui/react-slot';
 function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/utilities/slot/0.0.2/index.mdx
+++ b/pages/primitives/docs/utilities/slot/0.0.2/index.mdx
@@ -41,16 +41,16 @@ import { Slot } from '@radix-ui/react-slot';
 function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/utilities/slot/0.0.3/index.mdx
+++ b/pages/primitives/docs/utilities/slot/0.0.3/index.mdx
@@ -41,16 +41,16 @@ import { Slot } from '@radix-ui/react-slot';
 function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}

--- a/pages/primitives/docs/utilities/slot/0.0.4/index.mdx
+++ b/pages/primitives/docs/utilities/slot/0.0.4/index.mdx
@@ -41,16 +41,16 @@ import { Slot } from '@radix-ui/react-slot';
 function Tooltip({
   children,
   content,
-  isOpen,
-  defaultIsOpen,
-  onIsOpenChange,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }) {
   return (
     <TooltipPrimitive.Root
-      isOpen={isOpen}
-      defaultIsOpen={defaultIsOpen}
-      onIsOpenChange={onIsOpenChange}
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger as={Slot}>
         {children}


### PR DESCRIPTION
I noticed some of the code examples on `Tooltip` and `Slot` were using the old APIs.