### PR TITLE
Add `extendPrimitive` to styling

### DIFF
--- a/pages/primitives/docs/overview/styling.mdx
+++ b/pages/primitives/docs/overview/styling.mdx
@@ -24,6 +24,8 @@ When components are stateful, their state will be exposed in a `data-state` attr
 
 You can style a component part by targeting the `className` that you provide.
 
+We expose an `extendPrimitive` utility as a convenience for adding default props like `className`.
+
 ```css
 .accordion-item {
   border-bottom: 1px solid gainsboro;
@@ -32,6 +34,19 @@ You can style a component part by targeting the `className` that you provide.
 .accordion-panel {
   padding: 10px;
 }
+```
+
+```jsx
+import { extendPrimitive } from '@radix-ui/react-primitive';
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+
+const AccordionItem = extendPrimitive(AccordionPrimitive.Item, {
+  className: 'accordion-item',
+});
+
+const AccordionPanel = extendPrimitive(AccordionPrimitive.Panel, {
+  className: 'accordion-panel',
+});
 ```
 
 ### Styling a state


### PR DESCRIPTION
Updates styling docs to expose `extendPrimitive` utility that consumers can use for easily adding default props to our primitives (including default `as` prop that maintains polymorphism).