### PR TITLE
Missing slash in accordion docs.

### DIFF
--- a/pages/primitives/docs/components/accordion/0.0.7/index.mdx
+++ b/pages/primitives/docs/components/accordion/0.0.7/index.mdx
@@ -35,7 +35,7 @@ export default () => (
     <Accordion.Item>
       <Accordion.Header>
         <Accordion.Button />
-      <Accordion.Header>
+      </Accordion.Header>
       <Accordion.Panel />
     </Accordion.Item>
   </Accordion.Root>


### PR DESCRIPTION
Tiny fix to accordion example code.