### PR TITLE
Show what is "latest" version

### DIFF
--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -400,16 +400,18 @@ const ComponentInfo = ({ version, versions, name, aria }) => {
       </VisuallyHidden>
       <Separator size="2" css={{ mb: '$4', display: 'block', bp1: { display: 'none' } }} />
       <Flex css={{ mb: '$4', alignItems: 'baseline' }}>
-        <Text size="2" css={{ fontWeight: 500, mr: '$1' }}>
-          Version:
-        </Text>
-        <Select value={version} onChange={(e) => router.push(`./${e.target.value}`)}>
-          {versions.map((v) => (
-            <option key={v} value={v}>
-              {v}
-            </option>
-          ))}
-        </Select>
+        <Box css={{ mx: -5 }}>
+          <Select value={version} onChange={(e) => router.push(`./${e.target.value}`)}>
+            {versions.map((v, i) => {
+              return (
+                <option key={v} value={v}>
+                  {v}
+                  {i === 0 && ' (latest)'}
+                </option>
+              );
+            })}
+          </Select>
+        </Box>
       </Flex>
       <Separator size="2" css={{ mb: '$4', display: 'none', bp1: { display: 'block' } }} />
       <Box css={{ mb: '$2' }}>


### PR DESCRIPTION
After chatting with Colm, we decided on a slightly different way to the releases/changelog/history.
This change is something we worked out on the call together.

![image](https://user-images.githubusercontent.com/1539897/112620305-3f7a2800-8e20-11eb-9428-0d0037646f3c.png)
