### PR TITLE
Re-instate old `ToggleButton` docs under `Toggle`

### DIFF
--- a/pages/primitives/docs/components/toggle/0.0.1/index.mdx
+++ b/pages/primitives/docs/components/toggle/0.0.1/index.mdx
@@ -1,0 +1,141 @@
+---
+hideFromNav: true
+title: Toggle Button
+name: toggle-button
+description: A two-state button that can be either on or off.
+aria: https://www.w3.org/TR/wai-aria-practices-1.2/#button
+features:
+  - Full keyboard navigation.
+  - Can be controlled or uncontrolled.
+---
+
+import { ToggleHero } from '../../../../../../components/Hero/ToggleHero';
+
+<HeroSlot>
+  <ToggleHero />
+</HeroSlot>
+
+## Installation
+
+Install the component from your command line.
+
+```bash
+npm install @radix-ui/react-toggle-button
+```
+
+## Anatomy
+
+Import the component.
+
+```jsx
+import * as ToggleButton from '@radix-ui/react-toggle-buton';
+
+export default () => <ToggleButton.Root />;
+```
+
+## Basic example
+
+Create your styled toggle button component from the primitive parts.
+
+```jsx manual
+// import { styled } from 'path-to/stitches.config';
+import * as ToggleButton from '@radix-ui/react-toggle-button';
+
+const StyledToggleButton = styled(ToggleButton.Root, {
+  appearance: 'none',
+  backgroundColor: 'transparent',
+  border: 'none',
+  padding: '5px 10px',
+  boxShadow: 'inset 0 0 0 1px gainsboro',
+  overflow: 'hidden',
+  borderRadius: 3,
+
+  '&:focus': {
+    outline: 'none',
+    boxShadow: 'inset 0 0 0 1px dodgerblue, 0 0 0 1px dodgerblue',
+  },
+
+  '&[data-state=on]': {
+    backgroundColor: 'gainsboro',
+  },
+});
+
+export default () => <StyledToggleButton>Toggle</StyledToggleButton>;
+```
+
+<Note>
+
+**Note:** This example uses [Stitches](https://stitches.dev) but any styling solution is [compatible](../../overview/styling).
+
+</Note>
+
+## API Reference
+
+### Root
+
+The toggle button.
+
+<PropsTable
+  data={[
+    {
+      name: 'as',
+      required: false,
+      type: 'keyof JSX.IntrinsicElements | React.ComponentType<any>',
+      typeSimple: 'enum',
+      default: 'button',
+      description:
+        'Change the component to a different HTML tag or custom component. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node.',
+    },
+    {
+      name: 'defaultToggled',
+      type: 'boolean',
+      description:
+        'The toggled state of the toggle button when it is initially rendered. Use when you do not need to control its toggled state.',
+    },
+    {
+      name: 'toggled',
+      type: 'boolean',
+      description: (
+        <span>
+          The controlled toggled state of the toggle button. Must be
+          used in conjunction with in conjunction with{' '}
+          <Code>onToggledChange</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onToggledChange',
+      type: '(toggled: boolean) => void',
+      typeSimple: 'function',
+      description:
+        'Event handler called when the toggled state of the toggle button changes.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      description: (
+        <span>
+          When <Code>true</Code>, prevents the user from interacting
+          with the toggle button.
+        </span>
+      ),
+    },
+  ]}
+/>
+
+## Accessibility
+
+### Keyboard Interactions
+
+<KeyboardTable
+  data={[
+    {
+      keys: ['Space'],
+      description: 'Activates/deactivates the toggle button.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Activates/deactivates the toggle button.',
+    },
+  ]}
+/>

--- a/pages/primitives/docs/components/toggle/0.0.5/index.mdx
+++ b/pages/primitives/docs/components/toggle/0.0.5/index.mdx
@@ -1,0 +1,154 @@
+---
+hideFromNav: true
+title: Toggle Button
+name: toggle-button
+description: A two-state button that can be either on or off.
+aria: https://www.w3.org/TR/wai-aria-practices-1.2/#button
+features:
+  - Full keyboard navigation.
+  - Can be controlled or uncontrolled.
+---
+
+import { ToggleHero } from '../../../../../../components/Hero/ToggleHero';
+
+<HeroSlot>
+  <ToggleHero />
+</HeroSlot>
+
+## Installation
+
+Install the component from your command line.
+
+```bash
+npm install @radix-ui/react-toggle-button
+```
+
+## Anatomy
+
+Import the component.
+
+```jsx
+import * as ToggleButton from '@radix-ui/react-toggle-buton';
+
+export default () => <ToggleButton.Root />;
+```
+
+## Basic example
+
+Create your styled toggle button component from the primitive parts.
+
+```jsx manual
+// import { styled } from 'path-to/stitches.config';
+import * as ToggleButton from '@radix-ui/react-toggle-button';
+
+const StyledToggleButton = styled(ToggleButton.Root, {
+  appearance: 'none',
+  backgroundColor: 'transparent',
+  border: 'none',
+  padding: '5px 10px',
+  boxShadow: 'inset 0 0 0 1px gainsboro',
+  overflow: 'hidden',
+  borderRadius: 3,
+
+  '&:focus': {
+    outline: 'none',
+    boxShadow: 'inset 0 0 0 1px dodgerblue, 0 0 0 1px dodgerblue',
+  },
+
+  '&[data-state=on]': {
+    backgroundColor: 'gainsboro',
+  },
+});
+
+export default () => <StyledToggleButton>Toggle</StyledToggleButton>;
+```
+
+<Note>
+
+**Note:** This example uses [Stitches](https://stitches.dev) but any styling solution is [compatible](../../overview/styling).
+
+</Note>
+
+## API Reference
+
+### Root
+
+The toggle button.
+
+<PropsTable
+  data={[
+    {
+      name: 'as',
+      required: false,
+      type: 'keyof JSX.IntrinsicElements | React.ComponentType<any>',
+      typeSimple: 'enum',
+      default: 'button',
+      description:
+        'Change the component to a different HTML tag or custom component. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node.',
+    },
+    {
+      name: 'selector',
+      required: false,
+      type: 'string | null',
+      default: 'radix-toggle-button',
+      description: (
+        <span>
+          A string to use as the component selector for CSS purposes.
+          It will be added as a data attribute. Pass <Code>null</Code>{' '}
+          to remove selector.
+        </span>
+      ),
+    },
+    {
+      name: 'defaultToggled',
+      type: 'boolean',
+      description:
+        'The toggled state of the toggle button when it is initially rendered. Use when you do not need to control its toggled state.',
+    },
+    {
+      name: 'toggled',
+      type: 'boolean',
+      description: (
+        <span>
+          The controlled toggled state of the toggle button. Must be
+          used in conjunction with in conjunction with{' '}
+          <Code>onToggledChange</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onToggledChange',
+      type: '(toggled: boolean) => void',
+      typeSimple: 'function',
+      description:
+        'Event handler called when the toggled state of the toggle button changes.',
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      description: (
+        <span>
+          When <Code>true</Code>, prevents the user from interacting
+          with the toggle button.
+        </span>
+      ),
+    },
+  ]}
+/>
+
+## Accessibility
+
+### Keyboard Interactions
+
+<KeyboardTable
+  data={[
+    {
+      keys: ['Space'],
+      description: 'Activates/deactivates the toggle button.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Activates/deactivates the toggle button.',
+    },
+  ]}
+/>

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,5 +17,6 @@ export type FrontMatter = {
   version: string;
   versions?: string[];
   aria?: string;
+  hideFromNav?: boolean;
   __resourcePath: string;
 };

--- a/utils/primitives.ts
+++ b/utils/primitives.ts
@@ -21,7 +21,7 @@ export const overviewPages: FrontMatter[] = allPages
 
 export const componentsPages: FrontMatter[] = getLatestVersion(
   allPages
-    .filter((page) => page.id.includes('/components/'))
+    .filter((page) => page.id.includes('/components/') && !page.hideFromNav)
     .sort((a, b) => a.name.localeCompare(b.name))
 );
 


### PR DESCRIPTION
This PR re-instates the history of `Toggle` by adding the `ToggleButton` docs inside it as the package was renamed.
Everything works well, the only thing that was needed was to add a frontmatter metadata to hide some components from the nav as we do not want to see both `Toggle` and `ToggleButton` entries, but instead of we find `ToggleButton` old versions under the now latest `Toggle`.