### PR TITLE
Add design-system docs

### DIFF
--- a/components/DesignSystemPage.tsx
+++ b/components/DesignSystemPage.tsx
@@ -6,9 +6,9 @@ import { HamburgerMenuIcon } from '@radix-ui/react-icons';
 import { ScrollArea } from '../components/ScrollArea';
 import { RadixLogo } from './RadixLogo';
 import { ThemeToggle } from '@components/ThemeToggle';
-import { allPrimitivesRoutes, primitivesRoutes } from '@lib/primitivesRoutes';
+import { allDesignSystemRoutes, designSystemRoutes } from '@lib/designSystemRoutes';
 
-export function DocsPage({ children }: { children: React.ReactNode }) {
+export function DesignSystemPage({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -28,9 +28,9 @@ export function DocsPage({ children }: { children: React.ReactNode }) {
     editUrl = `${GITHUB_URL}/${REPO_NAME}/edit/main/data/${currentPageSlug}/${routerSlug[1]}.mdx`;
   }
 
-  const currentPageIndex = allPrimitivesRoutes.findIndex((page) => page.slug === currentPageSlug);
-  const previous = allPrimitivesRoutes[currentPageIndex - 1];
-  const next = allPrimitivesRoutes[currentPageIndex + 1];
+  const currentPageIndex = allDesignSystemRoutes.findIndex((page) => page.slug === currentPageSlug);
+  const previous = allDesignSystemRoutes[currentPageIndex - 1];
+  const next = allDesignSystemRoutes[currentPageIndex + 1];
 
   React.useEffect(() => {
     const handleRouteChange = () => setIsOpen(false);
@@ -123,7 +123,7 @@ export function DocsPage({ children }: { children: React.ReactNode }) {
               },
             }}
           >
-            {primitivesRoutes.map((section) => (
+            {designSystemRoutes.map((section) => (
               <Box key={section.label} css={{ mb: '$4' }}>
                 <NavHeading>{section.label}</NavHeading>
                 {section.pages.map((page) => {

--- a/data/design-system/docs/components/button/0.0.1.mdx
+++ b/data/design-system/docs/components/button/0.0.1.mdx
@@ -1,0 +1,6 @@
+---
+metaTitle: Button
+name: button
+---
+
+Coming soon.

--- a/data/design-system/docs/overview/introduction.mdx
+++ b/data/design-system/docs/overview/introduction.mdx
@@ -1,0 +1,11 @@
+---
+metaTitle: Introduction
+metaDescription: An open-source design system for building high-quality, accessible design systems and web apps.
+---
+
+# Introduction
+
+<Description>
+  An open-source design system for building high-quality, accessible
+  design systems and web apps.
+</Description>

--- a/lib/designSystemRoutes.ts
+++ b/lib/designSystemRoutes.ts
@@ -1,0 +1,18 @@
+export const designSystemRoutes = [
+  {
+    label: 'Overview',
+    pages: [
+      { title: 'Introduction', slug: 'design-system/docs/overview/introduction', draft: false },
+    ],
+  },
+
+  {
+    label: 'Components',
+    pages: [{ title: 'Button', slug: 'design-system/docs/components/button', draft: false }],
+  },
+];
+
+export const allDesignSystemRoutes = designSystemRoutes.reduce((acc, curr) => {
+  acc = [...acc, ...curr.pages.filter((p) => p.draft !== true)];
+  return acc;
+}, []);

--- a/lib/primitivesRoutes.ts
+++ b/lib/primitivesRoutes.ts
@@ -1,4 +1,4 @@
-export const docsRoutes = [
+export const primitivesRoutes = [
   {
     label: 'Overview',
     pages: [
@@ -58,7 +58,7 @@ export const docsRoutes = [
   },
 ];
 
-export const allDocsRoutes = docsRoutes.reduce((acc, curr) => {
+export const allPrimitivesRoutes = primitivesRoutes.reduce((acc, curr) => {
   acc = [...acc, ...curr.pages.filter((p) => p.draft !== true)];
   return acc;
 }, []);

--- a/next.config.js
+++ b/next.config.js
@@ -65,11 +65,18 @@ module.exports = withPlugins([withTM, withOptimizedImages, withVideos], {
     const utilitiesPaths = getPaths(utilitiesDirectory);
     const latestUtilitiesPaths = getPathOfLatestVersion(utilitiesPaths);
 
-    return [...latestPrimitivesPaths, ...latestUtilitiesPaths].reduce((redirects, paths, index) => {
-      const [, destination] = paths.split('/data');
-      const [, source] = path.join(paths, '..').split('/data');
-      redirects.push({ source, destination });
-      return redirects;
-    }, []);
+    const designSystemDirectory = path.join(__dirname, 'data/design-system/docs/components');
+    const designSystemPaths = getPaths(designSystemDirectory);
+    const latestDesignSystemPaths = getPathOfLatestVersion(designSystemPaths);
+
+    return [...latestPrimitivesPaths, ...latestUtilitiesPaths, ...latestDesignSystemPaths].reduce(
+      (redirects, paths, index) => {
+        const [, destination] = paths.split('/data');
+        const [, source] = path.join(paths, '..').split('/data');
+        redirects.push({ source, destination });
+        return redirects;
+      },
+      []
+    );
   },
 });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -47,6 +47,7 @@ function App({ Component, pageProps }: AppProps) {
 
   const isPrimitivesDocs = router.pathname.includes('/primitives/docs');
   const isDesignSystemDocs = router.pathname.includes('/design-system/docs');
+  const shouldShowFooter = !isPrimitivesDocs || !isDesignSystemDocs;
 
   return (
     <DesignSystemProvider>
@@ -67,7 +68,7 @@ function App({ Component, pageProps }: AppProps) {
         ) : (
           <Component {...pageProps} />
         )}
-        {!isPrimitivesDocs && <Footer />}
+        {!shouldShowFooter && <Footer />}
       </ThemeProvider>
     </DesignSystemProvider>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'next-themes';
 import { global, darkTheme, DesignSystemProvider } from '@modulz/design-system';
 import { Footer } from '@components/Footer';
 import { DocsPage } from '@components/DocsPage';
+import { DesignSystemPage } from '@components/DesignSystemPage';
 import { useAnalytics } from '@lib/analytics';
 import { scrollToUrlHash } from '@lib/scrollToUrlHash';
 
@@ -44,7 +45,8 @@ function App({ Component, pageProps }: AppProps) {
     scrollToUrlHash(router.asPath);
   }, []);
 
-  const isDocs = router.pathname.includes('/docs');
+  const isPrimitivesDocs = router.pathname.includes('/primitives/docs');
+  const isDesignSystemDocs = router.pathname.includes('/design-system/docs');
 
   return (
     <DesignSystemProvider>
@@ -54,14 +56,18 @@ function App({ Component, pageProps }: AppProps) {
         value={{ light: 'light-theme', dark: darkTheme.className }}
         defaultTheme="system"
       >
-        {isDocs ? (
+        {isPrimitivesDocs ? (
           <DocsPage>
             <Component {...pageProps} />
           </DocsPage>
+        ) : isDesignSystemDocs ? (
+          <DesignSystemPage>
+            <Component {...pageProps} />
+          </DesignSystemPage>
         ) : (
           <Component {...pageProps} />
         )}
-        {!isDocs && <Footer />}
+        {!isPrimitivesDocs && <Footer />}
       </ThemeProvider>
     </DesignSystemProvider>
   );

--- a/pages/design-system/docs/components/[...slug].tsx
+++ b/pages/design-system/docs/components/[...slug].tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import renderToString from 'next-mdx-remote/render-to-string';
+import hydrate from 'next-mdx-remote/hydrate';
+import { Box } from '@modulz/design-system';
+import remarkAutolinkHeadings from 'remark-autolink-headings';
+import remarkSlug from 'remark-slug';
+import { RemoveScroll } from 'react-remove-scroll';
+import { TitleAndMetaTags } from '@components/TitleAndMetaTags';
+import { components, createProvider } from '@components/MDXComponents';
+import { QuickNav } from '@components/QuickNav';
+import { OldVersionNote } from '@components/OldVersionNote';
+import { getAllFrontmatter, getAllVersionsFromPath, getDocBySlug } from '@lib/mdx';
+import rehypeHighlightCode from '@lib/rehype-highlight-code';
+
+import type { PrimitivesFrontmatter } from 'types/primitives';
+import type { MdxRemote } from 'next-mdx-remote/types';
+
+type Doc = {
+  frontmatter: PrimitivesFrontmatter;
+  source: MdxRemote.Source;
+};
+
+export default function DesignSystemDoc({ frontmatter, source }: Doc) {
+  const content = hydrate(source, { components, provider: createProvider(frontmatter) });
+
+  return (
+    <>
+      <TitleAndMetaTags
+        title={`${frontmatter.metaTitle} — Radix UI`}
+        description={frontmatter.metaDescription}
+        image={frontmatter.metaImage}
+      />
+
+      {frontmatter.version !== frontmatter.versions?.[0] && (
+        <OldVersionNote
+          name={frontmatter.metaTitle}
+          href={`/design-system/docs/components/${frontmatter.slug.replace(
+            frontmatter.version,
+            ''
+          )}`}
+        />
+      )}
+
+      {content}
+
+      <Box
+        as="aside"
+        // Components that hide the scrollbar (like Dialog) add padding to
+        // account for the scrollbar gap to avoid layout jank. This does not
+        // work for position: fixed elements. Since we use react-remove-scroll
+        // under the hood for those primitives, we can add this helper class
+        // provided by that lib to deal with that for the QuickNav.
+        // https://github.com/radix-ui/website/issues/64
+        // https://github.com/theKashey/react-remove-scroll#positionfixed-elements
+        className={RemoveScroll.classNames.zeroRight}
+        css={{
+          display: 'none',
+          '@bp3': {
+            display: 'block',
+            width: 250,
+            flexShrink: 0,
+            zIndex: 1,
+            position: 'fixed',
+            top: 0,
+            right: 0,
+            bottom: 0,
+          },
+        }}
+      >
+        <QuickNav content={content} />
+      </Box>
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  const frontmatters = getAllFrontmatter('design-system/docs/components');
+
+  return {
+    paths: frontmatters.map((frontmatter) => ({
+      params: { slug: frontmatter.slug.replace('design-system/docs/components/', '').split('/') },
+    })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps(context) {
+  const { frontmatter, content } = getDocBySlug(
+    'design-system/docs/components',
+    context.params.slug.join('/')
+  );
+
+  const [componentName, componentVersion] = context.params.slug;
+
+  const extendedFrontmatter = {
+    ...frontmatter,
+    version: componentVersion,
+    versions: getAllVersionsFromPath(`design-system/docs/components/${componentName}`),
+  };
+
+  const mdxContent = await renderToString(content, {
+    components,
+    provider: createProvider(extendedFrontmatter),
+    mdxOptions: {
+      remarkPlugins: [remarkAutolinkHeadings, remarkSlug],
+      rehypePlugins: [rehypeHighlightCode],
+    },
+  });
+
+  return {
+    props: {
+      frontmatter: extendedFrontmatter,
+      source: mdxContent,
+    },
+  };
+}

--- a/pages/design-system/docs/overview/[slug].tsx
+++ b/pages/design-system/docs/overview/[slug].tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import renderToString from 'next-mdx-remote/render-to-string';
+import hydrate from 'next-mdx-remote/hydrate';
+import { Text, Box } from '@modulz/design-system';
+import { TitleAndMetaTags } from '@components/TitleAndMetaTags';
+import { createProvider, components } from '@components/MDXComponents';
+import { getAllFrontmatter, getDocBySlug } from '@lib/mdx';
+import rehypeHighlightCode from '@lib/rehype-highlight-code';
+import remarkAutolinkHeadings from 'remark-autolink-headings';
+import remarkSlug from 'remark-slug';
+import { RemoveScroll } from 'react-remove-scroll';
+import { QuickNav } from '@components/QuickNav';
+
+import type { PrimitivesFrontmatter } from 'types/primitives';
+import type { MdxRemote } from 'next-mdx-remote/types';
+
+type Doc = {
+  frontmatter: PrimitivesFrontmatter;
+  source: MdxRemote.Source;
+};
+
+export default function DesignSystemOverviewDoc({ frontmatter, source }: Doc) {
+  const content = hydrate(source, { components, provider: createProvider(frontmatter) });
+
+  return (
+    <>
+      <TitleAndMetaTags
+        title={`${frontmatter.metaTitle} — Radix UI`}
+        description={frontmatter.metaDescription}
+        image={frontmatter.metaImage}
+      />
+
+      {content}
+
+      <Box
+        as="aside"
+        // Components that hide the scrollbar (like Dialog) add padding to
+        // account for the scrollbar gap to avoid layout jank. This does not
+        // work for position: fixed elements. Since we use react-remove-scroll
+        // under the hood for those primitives, we can add this helper class
+        // provided by that lib to deal with that for the QuickNav.
+        // https://github.com/radix-ui/website/issues/64
+        // https://github.com/theKashey/react-remove-scroll#positionfixed-elements
+        className={RemoveScroll.classNames.zeroRight}
+        css={{
+          display: 'none',
+          '@bp3': {
+            display: 'block',
+            width: 250,
+            flexShrink: 0,
+            zIndex: 1,
+            position: 'fixed',
+            top: 0,
+            right: 0,
+            bottom: 0,
+          },
+        }}
+      >
+        <QuickNav content={content} />
+      </Box>
+    </>
+  );
+}
+
+export async function getStaticPaths() {
+  const frontmatters = getAllFrontmatter('design-system/docs/overview');
+
+  return {
+    paths: frontmatters.map((frontmatter) => ({
+      params: { slug: frontmatter.slug.replace('design-system/docs/overview/', '') },
+    })),
+    fallback: false,
+  };
+}
+
+export async function getStaticProps(context) {
+  const { frontmatter, content } = getDocBySlug('design-system/docs/overview', context.params.slug);
+
+  const mdxContent = await renderToString(content, {
+    components,
+    provider: createProvider(frontmatter),
+    mdxOptions: {
+      remarkPlugins: [remarkAutolinkHeadings, remarkSlug],
+      rehypePlugins: [rehypeHighlightCode],
+    },
+  });
+
+  return { props: { frontmatter, source: mdxContent } };
+}


### PR DESCRIPTION
This PR adds support for design system docs

ATM it works exactly the same as the primitive docs. I've duplicated everything so we can make changes to each docs independently without worrying about abstractions

https://website-git-design-system-docs-radix-ui.vercel.app/design-system/docs/overview/introduction