### PR TITLE
Fix missing "full" type popover

### DIFF
--- a/components/PropsTable.tsx
+++ b/components/PropsTable.tsx
@@ -102,15 +102,15 @@ export function PropsTable({
                       verticalAlign: 'middle',
                       color: '$gray900',
                       display: 'none',
-                      bp1: { display: 'inline-flex' },
+                      '@bp1': { display: 'inline-flex' },
                     }}
                   >
                     <AccessibleIcon label="See full type">
                       <InfoCircledIcon />
                     </AccessibleIcon>
                   </PopoverTrigger>
-                  <PopoverContent side="top">
-                    <Box css={{ py: '$2', px: '$2', height: '38px', whiteSpace: 'nowrap' }}>
+                  <PopoverContent side="top" css={{ maxWidth: 'max-content' }}>
+                    <Box css={{ py: '$2', px: '$2', whiteSpace: 'nowrap' }}>
                       <Code>{type}</Code>
                     </Box>
                   </PopoverContent>


### PR DESCRIPTION
Not sure when this happened but I noticed the popover for the "full" type in our props tables was not visible.
It seems it would have been since an update of stitches as the breakpoint syntax as changed.

I've also tweaked some CSS as I think a DS update came with a `maxWidth: 256` for `PopoverContent` but for those types they don't wrap so they need to extend to the content. Also removed the hardcoded height, not sure why it was there in the first place…