### PR TITLE
[RadioGroup] Remove name from PropsTable

### DIFF
--- a/data/primitives/components/radio-group/0.0.16.mdx
+++ b/data/primitives/components/radio-group/0.0.16.mdx
@@ -205,12 +205,6 @@ An item in the group that can be checked.
         'Change the component to a different HTML tag or custom component. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node.',
     },
     {
-      name: 'name',
-      type: 'string',
-      description:
-        'The name of the radio item. Submitted with its owning form as part of a name/value pair.',
-    },
-    {
       name: 'value',
       type: 'string',
       description: (


### PR DESCRIPTION
The name prop is no longer necessary as the name is propagated from the RadioGroup.Root component as explained by @benoitgrelard  in this [closed issue](https://github.com/radix-ui/primitives/issues/655)


