### PR TITLE
Further fixes to RadioGroup docs

### DIFF
--- a/data/primitives/components/radio-group/0.0.1.mdx
+++ b/data/primitives/components/radio-group/0.0.1.mdx
@@ -105,7 +105,7 @@ export default () => (
 
 ## API Reference
 
-### RadioGroup
+### Root
 
 Contains all the parts of a radio group.
 

--- a/data/primitives/components/radio-group/0.0.14.mdx
+++ b/data/primitives/components/radio-group/0.0.14.mdx
@@ -105,7 +105,7 @@ export default () => (
 
 ## API Reference
 
-### RadioGroup
+### Root
 
 Contains all the parts of a radio group.
 

--- a/data/primitives/components/radio-group/0.0.16.mdx
+++ b/data/primitives/components/radio-group/0.0.16.mdx
@@ -110,7 +110,7 @@ export default () => (
 
 ## API Reference
 
-### RadioGroup
+### Root
 
 Contains all the parts of a radio group.
 
@@ -146,6 +146,12 @@ Contains all the parts of a radio group.
       type: '(value: string) => void',
       typeSimple: 'function',
       description: 'Event handler called when the value changes.',
+    },
+    {
+      name: 'name',
+      type: 'string',
+      description:
+        'The name of the group. Submitted with its owning form as part of a name/value pair.',
     },
     {
       name: 'required',

--- a/data/primitives/components/radio-group/0.0.6.mdx
+++ b/data/primitives/components/radio-group/0.0.6.mdx
@@ -105,7 +105,7 @@ export default () => (
 
 ## API Reference
 
-### RadioGroup
+### Root
 
 Contains all the parts of a radio group.
 


### PR DESCRIPTION
The `name` prop was removed from `Item` in #162 which is correct, but it seems it was never added to `Root` (was never moved back then basically).