### PR TITLE
Remove casting from polymorphic types

### DIFF
--- a/data/primitives/utilities/polymorphic/0.0.11.mdx
+++ b/data/primitives/utilities/polymorphic/0.0.11.mdx
@@ -42,9 +42,11 @@ Make a polymorphic `Box` component.
 import React from 'react';
 import type * as Polymorphic from '@radix-ui/react-polymorphic';
 
-const Box = React.forwardRef(({ as: Comp = 'div', ...props }, forwardedRef) => (
+type PolymorphicBox = Polymorphic.ForwardRefComponent<'div', {}>;
+
+const Box: PolymorphicBox = React.forwardRef(({ as: Comp = 'div', ...props }, forwardedRef) => (
   <Comp {...props} ref={forwardedRef} />
-)) as Polymorphic.ForwardRefComponent<'div', {}>;
+));
 
 export default () => <Box>
   <Box as="h1">This is a h1></Box>
@@ -56,7 +58,7 @@ export default () => <Box>
 
 ### ForwardRefComponent
 
-Cast your `forwardRef` component to this type to enable polymorphism.
+Types a `forwardRef` component as a polymorphic component.
 
 ```tsx line=1,4
 Polymorphic.ForwardRefComponent<
@@ -128,11 +130,11 @@ type PolymorphicDialogContent = Polymorphic.ForwardRefComponent<
   }
 >;
 
-const DialogContent = React.forwardRef(
+const DialogContent: PolymorphicDialogContent = React.forwardRef(
   ({ size = 'small', ...props }, forwardedRef) => (
     <Dialog.Content {...props} className={size} ref={forwardedRef} />
   )
-) as PolymorphicDialogContent;
+);
 
 export default () => (
   <Dialog.Root>

--- a/data/primitives/utilities/polymorphic/0.0.11.mdx
+++ b/data/primitives/utilities/polymorphic/0.0.11.mdx
@@ -58,7 +58,7 @@ export default () => <Box>
 
 ### ForwardRefComponent
 
-Types a `forwardRef` component as a polymorphic component.
+Adds polymorphic `as` prop types to a `forwardRef` component.
 
 ```tsx line=1,4
 Polymorphic.ForwardRefComponent<


### PR DESCRIPTION
Updates polymorphic docs to remove type casting recommendation. It seems some of the changes I've been making recently have meant we no longer need to cast. 

This approach will hopefully feel more natural to consumers as people tend to prefer to avoid casting.

Thanks @benoitgrelard for pointing out that we can do this without issue.