### PR TITLE
Fix broken "Edit this page on Github" url

### DIFF
--- a/components/ColorsPage.tsx
+++ b/components/ColorsPage.tsx
@@ -19,7 +19,7 @@ export function ColorsPage({ children }: { children: React.ReactNode }) {
 
   const GITHUB_URL = 'https://github.com';
   const REPO_NAME = 'radix-ui/website';
-  let editUrl = `${GITHUB_URL}/${REPO_NAME}/edit/main/data/${currentPageSlug}.mdx`;
+  let editUrl;
 
   if (typeof routerSlug === 'string') {
     currentPageSlug = router.pathname.substr(1).replace('[slug]', routerSlug);
@@ -227,7 +227,7 @@ export function ColorsPage({ children }: { children: React.ReactNode }) {
         <Container size="3" css={{ maxWidth: '780px', my: '$9' }}>
           <Text size="3">
             <Link
-              href={editUrl}
+              href={editUrl.replace('docs/', '')}
               title="Edit this page on GitHub."
               rel="noopener noreferrer"
               target="_blank"

--- a/components/ColorsPage.tsx
+++ b/components/ColorsPage.tsx
@@ -19,7 +19,7 @@ export function ColorsPage({ children }: { children: React.ReactNode }) {
 
   const GITHUB_URL = 'https://github.com';
   const REPO_NAME = 'radix-ui/website';
-  let editUrl;
+  let editUrl: string = '';
 
   if (typeof routerSlug === 'string') {
     currentPageSlug = router.pathname.substr(1).replace('[slug]', routerSlug);

--- a/components/DesignSystemPage.tsx
+++ b/components/DesignSystemPage.tsx
@@ -19,7 +19,7 @@ export function DesignSystemPage({ children }: { children: React.ReactNode }) {
 
   const GITHUB_URL = 'https://github.com';
   const REPO_NAME = 'radix-ui/website';
-  let editUrl = `${GITHUB_URL}/${REPO_NAME}/edit/main/data/${currentPageSlug}.mdx`;
+  let editUrl;
 
   if (typeof routerSlug === 'string') {
     currentPageSlug = router.pathname.substr(1).replace('[slug]', routerSlug);
@@ -227,7 +227,7 @@ export function DesignSystemPage({ children }: { children: React.ReactNode }) {
         <Container size="3" css={{ maxWidth: '780px', my: '$9' }}>
           <Text size="3">
             <Link
-              href={editUrl}
+              href={editUrl.replace('docs/', '')}
               title="Edit this page on GitHub."
               rel="noopener noreferrer"
               target="_blank"

--- a/components/DesignSystemPage.tsx
+++ b/components/DesignSystemPage.tsx
@@ -19,7 +19,7 @@ export function DesignSystemPage({ children }: { children: React.ReactNode }) {
 
   const GITHUB_URL = 'https://github.com';
   const REPO_NAME = 'radix-ui/website';
-  let editUrl;
+  let editUrl: string = '';
 
   if (typeof routerSlug === 'string') {
     currentPageSlug = router.pathname.substr(1).replace('[slug]', routerSlug);

--- a/components/PrimitivesPage.tsx
+++ b/components/PrimitivesPage.tsx
@@ -19,7 +19,7 @@ export function PrimitivesPage({ children }: { children: React.ReactNode }) {
 
   const GITHUB_URL = 'https://github.com';
   const REPO_NAME = 'radix-ui/website';
-  let editUrl;
+  let editUrl: string = '';
 
   if (typeof routerSlug === 'string') {
     currentPageSlug = router.pathname.substr(1).replace('[slug]', routerSlug);

--- a/components/PrimitivesPage.tsx
+++ b/components/PrimitivesPage.tsx
@@ -19,7 +19,7 @@ export function PrimitivesPage({ children }: { children: React.ReactNode }) {
 
   const GITHUB_URL = 'https://github.com';
   const REPO_NAME = 'radix-ui/website';
-  let editUrl = `${GITHUB_URL}/${REPO_NAME}/edit/main/data/${currentPageSlug}.mdx`;
+  let editUrl;
 
   if (typeof routerSlug === 'string') {
     currentPageSlug = router.pathname.substr(1).replace('[slug]', routerSlug);
@@ -227,7 +227,7 @@ export function PrimitivesPage({ children }: { children: React.ReactNode }) {
         <Container size="3" css={{ maxWidth: '780px', my: '$9' }}>
           <Text size="3">
             <Link
-              href={editUrl}
+              href={editUrl.replace('docs/', '')}
               title="Edit this page on GitHub."
               rel="noopener noreferrer"
               target="_blank"


### PR DESCRIPTION
This PR fixes the bug where the wrong URL would be generated for the Edit this page on Github button. Since the `docs` is inherited by the folder structure inside the `pages/docs` we need to replace it from the url.

There was also a initial value for editUrl which contains a `undefined.mdx` on the path since `currentPageSlug` is undefined. I think its more readable having the variable set to empty string, but this is arguable :)