### PR TITLE
fix scrollarea features typo

### DIFF
--- a/data/primitives/components/scroll-area/0.0.13.mdx
+++ b/data/primitives/components/scroll-area/0.0.13.mdx
@@ -18,7 +18,7 @@ name: scroll-area
     'Track sits on top of the scrollable content, taking up no space.',
     'Scrolling is native; no underlying position movements via CSS transformations.',
     'Shims pointer behaviors only when interacting with the controls, so keyboard controls are unaffected.',
-    "Progressively enhanced so that content is avalaible on devices where custom controls aren't supported.",
+    "Progressively enhanced so that content is available on devices where custom controls aren't supported.",
   ]}
 />
 


### PR DESCRIPTION
this pr fixes a tiny typo in the features list for the scrollarea component.

This pull request:
- [x] Updates documentation or example code
