### PR TITLE
[DropdownMenu][ContextMenu] Add missing `StyledSeparator` to examples

### DIFF
--- a/data/primitives/components/context-menu/0.0.21.mdx
+++ b/data/primitives/components/context-menu/0.0.21.mdx
@@ -778,6 +778,7 @@ You can create submenus by nesting `ContextMenu`s and using a `TriggerItem` in p
 ```jsx collapsed
 import { styled } from 'path-to/stitches.config';
 import * as ContextMenu from '@radix-ui/react-context-menu';
+
 const StyledContent = styled(ContextMenu.Content, {
   minWidth: 130,
   backgroundColor: 'white',
@@ -785,6 +786,7 @@ const StyledContent = styled(ContextMenu.Content, {
   padding: 5,
   boxShadow: '0px 5px 15px -5px hsla(206,22%,7%,.15)',
 });
+
 const itemStyles = {
   fontSize: 13,
   padding: '5px 10px',
@@ -799,7 +801,9 @@ const itemStyles = {
     color: 'white',
   },
 };
+
 const StyledItem = styled(ContextMenu.Item, itemStyles);
+
 const StyledTriggerItem = styled(ContextMenu.TriggerItem, {
   '&[data-state="open"]': {
     backgroundColor: 'hsl(206,10%,80%)',
@@ -807,9 +811,17 @@ const StyledTriggerItem = styled(ContextMenu.TriggerItem, {
   },
   ...itemStyles,
 });
+
+const StyledSeparator = styled(ContextMenu.Separator, {
+  height: 1,
+  backgroundColor: 'gainsboro',
+  margin: 5,
+});
+
 const StyledArrow = styled(ContextMenu.Arrow, {
   fill: 'white',
 });
+
 export default () => (
   <ContextMenu.Root>
     <ContextMenu.Trigger>

--- a/data/primitives/components/dropdown-menu/0.0.20.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.20.mdx
@@ -905,6 +905,12 @@ const StyledTriggerItem = styled(DropdownMenu.TriggerItem, {
   ...itemStyles,
 });
 
+const StyledSeparator = styled(DropdownMenu.Separator, {
+  height: 1,
+  backgroundColor: 'gainsboro',
+  margin: 5,
+});
+
 const StyledArrow = styled(DropdownMenu.Arrow, {
   fill: 'white',
 });


### PR DESCRIPTION
Corrects missing `StyledSeparator` in original submenu examples.