### PR TITLE
Fix typo in ScrollArea scrollbar property description

### DIFF
--- a/data/primitives/components/scroll-area/0.0.14.mdx
+++ b/data/primitives/components/scroll-area/0.0.14.mdx
@@ -235,7 +235,7 @@ The horizontal scrollbar.
       type: '"horizontal" | "vertical"',
       typeSimple: 'enum',
       default: 'vertical',
-      description: 'The orientation of the srollbar',
+      description: 'The orientation of the scrollbar',
     },
   ]}
 />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10568927/122783271-b43ef000-d2b1-11eb-9560-494ec8281a16.png)

This pull request:

- [X] Updates documentation or example code
