### PR TITLE
Remove extra angle bracket from polymorphic primitive basic example

### DIFF
--- a/data/primitives/utilities/polymorphic/0.0.12.mdx
+++ b/data/primitives/utilities/polymorphic/0.0.12.mdx
@@ -49,7 +49,7 @@ const Box: PolymorphicBox = React.forwardRef(({ as: Comp = 'div', ...props }, fo
 ));
 
 export default () => <Box>
-  <Box as="h1">This is a h1></Box>
+  <Box as="h1">This is a h1</Box>
   <Box as="button">This is a button</Box>
 </Box>
 ```


### PR DESCRIPTION
Removes an extra angle bracket from the polymorphic primitive basic example, which causes a typescript error when copy-pasted directly into an editor.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
