### PR TITLE
Fix imports in vanilla CSS example

### DIFF
--- a/data/colors/getting-started/usage.mdx
+++ b/data/colors/getting-started/usage.mdx
@@ -143,14 +143,14 @@ Radix Colors provides the colors bundled as raw CSS files. You can import them d
 
 ```js
 // Import only the scales you need
-import "@radix-ui/colors/gray.css";
-import "@radix-ui/colors/blue.css";
-import "@radix-ui/colors/green.css";
-import "@radix-ui/colors/red.css";
-import "@radix-ui/colors/grayDark.css";
-import "@radix-ui/colors/blueDark.css";
-import "@radix-ui/colors/greenDark.css";
-import "@radix-ui/colors/redDark.css";
+@import "@radix-ui/colors/gray.css";
+@import "@radix-ui/colors/blue.css";
+@import "@radix-ui/colors/green.css";
+@import "@radix-ui/colors/red.css";
+@import "@radix-ui/colors/grayDark.css";
+@import "@radix-ui/colors/blueDark.css";
+@import "@radix-ui/colors/greenDark.css";
+@import "@radix-ui/colors/redDark.css";
 
 // Use the colors as CSS variables
 .button {


### PR DESCRIPTION
I've noticed that vanilla CSS example was missing `@` at the beginning of import.

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
