### PR TITLE
Typo on Radix Colors usage on site

### DIFF
--- a/data/colors/getting-started/usage.mdx
+++ b/data/colors/getting-started/usage.mdx
@@ -19,10 +19,12 @@ import {
   blue,
   green,
   red,
+  yellow,
   grayDark,
   blueDark,
   greenDark,
   redDark,
+  yellowDark,
 } from '@radix-ui/colors';
 
 // Spread the scales in your light and dark themes

--- a/data/colors/getting-started/usage.mdx
+++ b/data/colors/getting-started/usage.mdx
@@ -17,14 +17,12 @@ Radix Colors scales are just simple JavaScript objects, so you can use them with
 import {
   gray,
   blue,
-  green,
   red,
-  yellow,
+  green,
   grayDark,
   blueDark,
-  greenDark,
   redDark,
-  yellowDark,
+  greenDark,
 } from '@radix-ui/colors';
 
 // Spread the scales in your light and dark themes
@@ -34,10 +32,9 @@ const { styled, theme } = createCss({
   theme: {
     colors: {
       ...gray,
-      ...red,
       ...blue,
+      ...red,
       ...green,
-      ...yellow,
     },
   },
 });
@@ -45,10 +42,9 @@ const { styled, theme } = createCss({
 const darkTheme = theme({
   colors: {
     ...grayDark,
-    ...redDark,
     ...blueDark,
+    ...redDark,
     ...greenDark,
-    ...yellowDark,
   },
 });
 


### PR DESCRIPTION
Got an error on Radix Colors usage stitches example because the import was missing the `yellow` import to spread on stitches colors object. So I Added yellow import missing on stitches usage.

This pull request:

- [x] Updates documentation or example code
