### PR TITLE
Primitives – Fix typo on styling page

### DIFF
--- a/data/primitives/overview/styling.mdx
+++ b/data/primitives/overview/styling.mdx
@@ -73,7 +73,7 @@ const AccordionItem = React.forwardRef((props, forwardedRef) => {
 }) as AccordionItemComponent;
 ```
 
-Alternatively, we expose an `extendPrimitive` utility as a convenience for adding default props while retaining polymoprhism. It can be useful if your preference is to style data attributes as they needn't be composed like class names.
+Alternatively, we expose an `extendPrimitive` utility as a convenience for adding default props while retaining polymorphism. It can be useful if your preference is to style data attributes as they needn't be composed like class names.
 
 ```jsx
 import { extendPrimitive } from '@radix-ui/react-primitive';


### PR DESCRIPTION
`polymoprhism` to `polymorphism`.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [X] Updates documentation or example code
- [ ] Other
