### PR TITLE
[Colors docs] Fix typos in Aliasing ## Use case aliases

### DIFF
--- a/data/colors/getting-started/aliasing.mdx
+++ b/data/colors/getting-started/aliasing.mdx
@@ -421,8 +421,8 @@ It's intended for prototyping only. */
 
 Again, with this approach, you will likely run into issues where you need to use the same step for multiple use cases. Common examples include:
 
-- Step 8 is designed for solid backgrounds, but it also works well for input placeholder text.
-- Step 7 is designed for hovered component borders, but it also works well for focus rings.
+- Step 9 is designed for solid backgrounds, but it also works well for input placeholder text.
+- Step 8 is designed for hovered component borders, but it also works well for focus rings.
 
 In these cases, you can choose to define multiple aliases which map to the same step.
 


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

The documentation mentioned 1 step below the correct ones, 9 is for solid backgrounds and 8 for hovered component borders.
This pull request fixes this typo. 
https://www.radix-ui.com/docs/colors/getting-started/aliasing#use-case-aliases
