### PR TITLE
Replace createCss with the current createStitches

### DIFF
--- a/data/colors/getting-started/usage.mdx
+++ b/data/colors/getting-started/usage.mdx
@@ -26,9 +26,9 @@ import {
 } from '@radix-ui/colors';
 
 // Spread the scales in your light and dark themes
-import { createCss } from '@stitches/react';
+import { createStitches } from '@stitches/react';
 
-const { styled, theme } = createCss({
+const { styled, theme } = createStitches({
   theme: {
     colors: {
       ...gray,


### PR DESCRIPTION
Hi,
this PR updates the usage documentation (https://www.radix-ui.com/docs/colors/getting-started/usage) to work with the most current version of stitches.
https://github.com/modulz/stitches/issues/682

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
