### PR TITLE
Remove periods from the colors' "Understanding the scale" table

### DIFF
--- a/components/UseCasesTable.tsx
+++ b/components/UseCasesTable.tsx
@@ -64,7 +64,7 @@ export function UseCasesTable() {
             <Text size="2">4</Text>
           </Td>
           <Td css={{ px: '$4' }}>
-            <Text size="2">Hovered UI element background.</Text>
+            <Text size="2">Hovered UI element background</Text>
           </Td>
         </Tr>
         <Tr>
@@ -72,7 +72,7 @@ export function UseCasesTable() {
             <Text size="2">5</Text>
           </Td>
           <Td css={{ px: '$4' }}>
-            <Text size="2">Active / Selected UI element background.</Text>
+            <Text size="2">Active / Selected UI element background</Text>
           </Td>
         </Tr>
         <Tr>
@@ -80,7 +80,7 @@ export function UseCasesTable() {
             <Text size="2">6</Text>
           </Td>
           <Td css={{ px: '$4' }}>
-            <Text size="2">Subtle borders and separators.</Text>
+            <Text size="2">Subtle borders and separators</Text>
           </Td>
         </Tr>
         <Tr>
@@ -104,7 +104,7 @@ export function UseCasesTable() {
             <Text size="2">9</Text>
           </Td>
           <Td css={{ px: '$4' }}>
-            <Text size="2">Solid backgrounds.</Text>
+            <Text size="2">Solid backgrounds</Text>
           </Td>
         </Tr>
         <Tr>
@@ -112,7 +112,7 @@ export function UseCasesTable() {
             <Text size="2">10</Text>
           </Td>
           <Td css={{ px: '$4' }}>
-            <Text size="2">Hovered solid backgrounds.</Text>
+            <Text size="2">Hovered solid backgrounds</Text>
           </Td>
         </Tr>
         <Tr>
@@ -120,7 +120,7 @@ export function UseCasesTable() {
             <Text size="2">11</Text>
           </Td>
           <Td css={{ px: '$4' }}>
-            <Text size="2">Low-contrast text.</Text>
+            <Text size="2">Low-contrast text</Text>
           </Td>
         </Tr>
         <Tr>
@@ -128,7 +128,7 @@ export function UseCasesTable() {
             <Text size="2">12</Text>
           </Td>
           <Td css={{ px: '$4' }}>
-            <Text size="2">High-contrast text.</Text>
+            <Text size="2">High-contrast text</Text>
           </Td>
         </Tr>
       </Tbody>


### PR DESCRIPTION
I'm a lover of Radix Colors and use it for all of side projects. I screenshot the `docs/colors/palette-composition/understanding-the-scale#use-cases` table straight into my Figma project and custom SASS file. 

<img width="508" alt="CleanShot 2021-10-09 at 20 23 41@2x" src="https://user-images.githubusercontent.com/31426677/136680492-9e863e07-b88f-4a37-96d4-c8ab3fff65e3.png">

## Change

This PR is very minor edit. My suggested edit is to remove all the periods from the table for consistency.

---

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
