### PR TITLE
Main hero — keyboard navigation improvements

### DIFF
--- a/components/marketing/MainHero.tsx
+++ b/components/marketing/MainHero.tsx
@@ -254,6 +254,9 @@ export const MainHero = () => {
               // Use padding rather than margin, or otherwise some descenders
               // may be clipped with WebkitBackgroundClip: 'text'
               pb: '$4',
+              // Same issue, letters may be clipped horizontally
+              px: '$2',
+              mx: '-$2',
               fontWeight: 500,
               fontSize: 'min(max($8, 11.2vw), $9)',
               letterSpacing: 'max(min(-0.055em, -0.66vw), -0.07em)',

--- a/components/marketing/MainHero.tsx
+++ b/components/marketing/MainHero.tsx
@@ -635,6 +635,7 @@ const CarouselArrowButton = styled('button', {
 
   display: 'flex',
   position: 'relative',
+  zIndex: 1,
   ai: 'center',
   jc: 'center',
   bc: '$panel',


### PR DESCRIPTION
- Improve roving keyboard navigation on the carousel
- Add Esc key to exit a demo (press Enter to enter a demo when focused)
- Add aria labels for demos
  - I still want to do a few related improvements to make the demo experience nice for screen reader users; will figure it out in the next iteration.
- Fix miscellaneous related bugs
- (Unrelated) Fix slightly clipped “Why waste…” heading letters