### PR TITLE
Fix sandbox type error

### DIFF
--- a/components/DocCodeBlock.tsx
+++ b/components/DocCodeBlock.tsx
@@ -168,6 +168,7 @@ const makeCodeSandboxParams = (name, code) => {
           dependencies: {
             react: 'latest',
             'react-dom': 'latest',
+            'react-scripts': 'latest',
             '@stitches/react': 'latest',
             '@radix-ui/colors': 'latest',
             '@radix-ui/react-icons': 'latest',


### PR DESCRIPTION
We had reports of type errors in our demos
![image](https://user-images.githubusercontent.com/11708259/141983550-67f4f672-8dac-4b9d-a78b-fe2346f3a61d.png)

I'm still investigating but nothing changed on our end AFAIK, for now I've found adding `react-scripts` as a dependency to the generated sandbox resolves the issue.
