### PR TITLE
[Sandbox demos] Move react-scripts to dev dependencies

### DIFF
--- a/components/DocCodeBlock.tsx
+++ b/components/DocCodeBlock.tsx
@@ -168,11 +168,13 @@ const makeCodeSandboxParams = (name, code) => {
           dependencies: {
             react: 'latest',
             'react-dom': 'latest',
-            'react-scripts': 'latest',
             '@stitches/react': 'latest',
             '@radix-ui/colors': 'latest',
             '@radix-ui/react-icons': 'latest',
             [`@radix-ui/react-${name}`]: 'latest',
+          },
+          devDependencies: {
+            'react-scripts': 'latest',
           },
         } as any,
         isBinary: false,
@@ -196,7 +198,6 @@ ReactDOM.render(<div><App /></div>, document.getElementById('root'));`,
         isBinary: false,
       },
     },
-    template: 'create-react-app',
   });
 
   return parameters;


### PR DESCRIPTION
Original fix https://github.com/radix-ui/website/pull/276 should have added this as `devDependencies`

CSB came back with the same solution

> The sandbox didn't have react-scripts installed, which made our detection logic think that you were on react-scripts v1, which imports .cjs files as raw files. If you add react-scripts v4 to your devDependencies, we'll use the latest version of react-scripts, and it will work.

When asking about the reason this requirement would have changed:
> We did recently change our resolver logic, and we resolved the .cjs file instead of the .mjs file. That's the only thing that could explain it (I think).