### PR TITLE
[Release] Remove redundant changelog item

### DIFF
--- a/data/primitives/overview/releases.mdx
+++ b/data/primitives/overview/releases.mdx
@@ -36,7 +36,6 @@ metaDescription: Radix Primitives releases and their changelogs.
 
 <PackageRelease name="DropdownMenu" version="0.1.3" />
 
-- 🔥 Change `Dropdown.Trigger` to `button` element <PRLink id={981} />
 - 🐛 Prevent disabled trigger from opening menu <PRLink id={974} />
 
 <PackageRelease name="HoverCard" version="0.1.2" />


### PR DESCRIPTION
I'd copy/pasted a note about converting the `Dropdown.Trigger` to a `button` but the `Dropdown.Trigger` was always a button, we just updated its logic to use `onClick` in that case instead of `onKeyDown`.