### PR TITLE
[website] Prevent header shifting while scrolllocking

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,13 +21,14 @@ import { PlusIcon, MixIcon, StitchesLogoIcon } from '@radix-ui/react-icons';
 import { ThemeToggle } from '@components/ThemeToggle';
 import { BoxLink } from '@components/BoxLink';
 import { RadixLogoIcon } from './RadixLogoIcon';
+import { RemoveScroll } from 'react-remove-scroll';
 
 export const Header = () => {
   const router = useRouter();
   const isColors = router.pathname.includes('/colors') || router.pathname.includes('/docs/colors');
 
   return (
-    <Box as="header" className="width-before-scroll-bar">
+    <Box as="header" className={RemoveScroll.classNames.fullWidth}>
       <Container size="4">
         <Flex align="center" justify="between" css={{ height: '$8' }}>
           <NextLink href={isColors ? '/colors' : '/'} passHref>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -27,7 +27,7 @@ export const Header = () => {
   const isColors = router.pathname.includes('/colors') || router.pathname.includes('/docs/colors');
 
   return (
-    <Box as="header">
+    <Box as="header" className="width-before-scroll-bar">
       <Container size="4">
         <Flex align="center" justify="between" css={{ height: '$8' }}>
           <NextLink href={isColors ? '/colors' : '/'} passHref>


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.
^ Vercel bot will be a good soldier and add it for us

This pull request:

- [X] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

=========================================

react-remove-scroll expects you to add some classes to the containers potentially pushed around by the "removal" of the scrollbar, this PR adds it to the header (the body and quick nav already have what they need to not shift around)

=========================================

## Current behavior
![without2](https://user-images.githubusercontent.com/14223903/147523277-e037bca2-f40a-4988-81aa-752a2ae9f914.gif)
![without](https://user-images.githubusercontent.com/14223903/147523278-c2bf191d-fe07-421e-9d41-86dc1ac276ee.gif)

## With this change applied
![with2](https://user-images.githubusercontent.com/14223903/147523297-da3615d3-5181-4cd1-85f5-70cf19e14610.gif)
![withClass](https://user-images.githubusercontent.com/14223903/147523299-44819403-2c51-4fb7-82ac-bf3d672d315a.gif)

