### PR TITLE
typo(docs): Change <CollapsibleContent> to <Collapsible.Content>

### DIFF
--- a/data/primitives/components/collapsible/0.1.5.mdx
+++ b/data/primitives/components/collapsible/0.1.5.mdx
@@ -167,7 +167,7 @@ const CollapsibleContent = styled(Collapsible.Content, {
 export default () => (
   <Collapsible.Root>
     <Collapsible.Trigger>…</Collapsible.Trigger>
-    <CollapsibleContent>…</CollapsibleContent>
+    <Collapsible.Content>…</Collapsible.Content>
   </Collapsible.Root>
 );
 ```


### PR DESCRIPTION
This pull requests fixes a typo in the documentation for the `Collapsible` component (https://www.radix-ui.com/docs/primitives/components/collapsible).

The _[Animating content size](https://www.radix-ui.com/docs/primitives/components/collapsible#animating-content-size)_ example code currently has `<CollapsibleContent>` without a period between `Collapsible` and `Content`. This pull request adds the period.

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
