### PR TITLE
Contain docs page stacking context

### DIFF
--- a/components/PrimitivesPage.tsx
+++ b/components/PrimitivesPage.tsx
@@ -136,6 +136,7 @@ export function PrimitivesPage({ children }: { children: React.ReactNode }) {
           flex: 1,
           pt: '$8',
           pb: '$5',
+          zIndex: 0,
 
           '@bp2': { pb: '$9', pl: '250px' },
           '@media (min-width: 1440px)': { pr: '250px' },


### PR DESCRIPTION
Fix issue where inner docs stacking would bleed and compete with the site nav.

![image](https://user-images.githubusercontent.com/11708259/156029378-fafa52f4-1466-4b7d-aabb-3f3249ee58e1.png)

