### PR TITLE
`id` prop belongs to DropdownMenu.Content instead of Root

### DIFF
--- a/data/primitives/components/dropdown-menu/0.1.6.mdx
+++ b/data/primitives/components/dropdown-menu/0.1.6.mdx
@@ -147,17 +147,6 @@ Contains all the parts of a dropdown menu.
       description:
         'The reading direction of submenus when applicable. If omitted, assumes LTR (left-to-right) reading mode.',
     },
-    {
-      name: 'id',
-      type: 'string',
-      description: (
-        <span>
-          A unique identifier for the component. The <Code>id</Code> is used to
-          generate <Code>id</Code> attributes for nested components. If no{' '}
-          <Code>id</Code> prop is provided, a generated id will be used.
-        </span>
-      ),
-    },
   ]}
 />
 
@@ -376,6 +365,17 @@ The component that pops out when the dropdown menu is open.
         <span>
           The distance in pixels from window edges where collision detection
           should occur.
+        </span>
+      ),
+    },
+    {
+      name: 'id',
+      type: 'string',
+      description: (
+        <span>
+          A unique identifier for the component. The <Code>id</Code> is used to
+          generate <Code>id</Code> attributes for nested components. If no{' '}
+          <Code>id</Code> prop is provided, a generated id will be used.
         </span>
       ),
     },


### PR DESCRIPTION
As detailed [here](https://github.com/radix-ui/primitives/issues/1238), passing `id` to .Root doesn't work as expected (and as detailed in the documentation).
Moving this to .Content

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:
- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

Closes #356 