### PR TITLE
fix aria-labels on Carousel Previous/Next buttons

### DIFF
--- a/components/marketing/MainHero.tsx
+++ b/components/marketing/MainHero.tsx
@@ -676,7 +676,7 @@ export const MainHero = () => {
               left: '15px',
             }}
           >
-            <CarouselPrevious aria-label="Show next demo" tabIndex={-1} as={CarouselArrowButton}>
+            <CarouselPrevious aria-label="Show previous demo" tabIndex={-1} as={CarouselArrowButton}>
               <ArrowLeftIcon />
             </CarouselPrevious>
           </Box>
@@ -687,7 +687,7 @@ export const MainHero = () => {
               right: '15px',
             }}
           >
-            <CarouselNext aria-label="Show previous demo" tabIndex={-1} as={CarouselArrowButton}>
+            <CarouselNext aria-label="Show next demo" tabIndex={-1} as={CarouselArrowButton}>
               <ArrowRightIcon />
             </CarouselNext>
           </Box>


### PR DESCRIPTION
👋 hi! big fan of Radix and was poking around the source code, just noticed that the aria labels are swapped on the home page carousel previous/next buttons and figured I'd open a quick PR in case no one's caught it yet

- [ x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
