### PR TITLE
Toast mdx: Fix closing tag in Toast implementation examples

### DIFF
--- a/data/primitives/components/toast/0.1.1.mdx
+++ b/data/primitives/components/toast/0.1.1.mdx
@@ -520,7 +520,7 @@ export const Toast = ({ title, content, children, ...props }) => {
       <ToastPrimitive.Close aria-label="Close">
         <span aria-hidden>×</span>
       </ToastPrimitive.Close>
-    </ToastPrimitive>
+    </ToastPrimitive.Root>
   );
 };
 ```

--- a/data/primitives/components/toast/0.1.1.mdx
+++ b/data/primitives/components/toast/0.1.1.mdx
@@ -569,7 +569,7 @@ export const Toast = React.forwardRef((props, forwardedRef) => {
         <ToastPrimitive.Root key={index} {...toastProps}>
           <ToastPrimitive.Description>{children}</ToastPrimitive.Description>
           <ToastPrimitive.Close>Dismiss</ToastPrimitive.Close>
-        </ToastPrimitive>
+        </ToastPrimitive.Root>
       ))}
     </>
   );


### PR DESCRIPTION
Minor, but closing tag was missing a `.Root`, resulting in invalid JSX. Change is only to a code example in the documentation so I haven't done any additional testing.

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
