### PR TITLE
Dialog: Properly implement custom ref

### DIFF
--- a/data/primitives/components/dialog/0.1.7.mdx
+++ b/data/primitives/components/dialog/0.1.7.mdx
@@ -399,18 +399,18 @@ Customise the element that your dialog portals into.
 
 ```jsx line=2,13
 export default () => {
-  const [container, setContainer] = React.useState(null);
+  const container = React.useRef(null);
   return (
     <div>
       <Dialog.Root>
         <Dialog.Trigger />
-        <Dialog.Portal __container__={container}>
+        <Dialog.Portal __container__={container.current}>
           <Dialog.Overlay />
           <Dialog.Content>...</Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
 
-      <div ref={setContainer} />
+      <div ref={container} />
     </div>
   );
 };


### PR DESCRIPTION
Correctly implements `ref`. Setting useState worked, but it was triggering errors in Typescript do to `setContainer` not being a valid `ref` prop.

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
