### PR TITLE
[HoverCard] Fix incorrect prop name in example

### DIFF
--- a/data/primitives/components/hover-card/0.1.5.mdx
+++ b/data/primitives/components/hover-card/0.1.5.mdx
@@ -281,7 +281,7 @@ Use the `openDelay` prop to control the time it takes for the hover card to open
 import * as HoverCard from '@radix-ui/react-hover-card';
 
 export default () => (
-  <HoverCard.Root __delayDuration__={0}>
+  <HoverCard.Root openDelay={0}>
     <HoverCard.Trigger>…</HoverCard.Trigger>
     <HoverCard.Content>…</HoverCard.Content>
   </HoverCard.Root>

--- a/data/primitives/components/hover-card/0.1.5.mdx
+++ b/data/primitives/components/hover-card/0.1.5.mdx
@@ -281,7 +281,7 @@ Use the `openDelay` prop to control the time it takes for the hover card to open
 import * as HoverCard from '@radix-ui/react-hover-card';
 
 export default () => (
-  <HoverCard.Root openDelay={0}>
+  <HoverCard.Root __openDelay__={0}>
     <HoverCard.Trigger>…</HoverCard.Trigger>
     <HoverCard.Content>…</HoverCard.Content>
   </HoverCard.Root>


### PR DESCRIPTION
Changed the example's `delayDuration` prop to `openDelay` to match the API

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->
This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
