### PR TITLE
[Toast] Document label prop on provider

### DIFF
--- a/data/primitives/components/toast/0.1.1.mdx
+++ b/data/primitives/components/toast/0.1.1.mdx
@@ -73,6 +73,13 @@ The provider that wraps your toasts and toast viewport. It usually wraps the app
         'The time in milliseconds that should elapse before automatically closing each toast.',
     },
     {
+      name: 'label',
+      type: 'string',
+      default: '"Notification"',
+      description:
+        'An author-localized label for each toast. Used to help screen reader users associate the interruption with a toast.',
+    },
+    {
       name: 'swipeDirection',
       type: '"right" | "left" | "up" | "down"',
       typeSimple: 'enum',


### PR DESCRIPTION
Noticed this was missing from the original documentation