### PR TITLE
Correctly close DropdownMenu.Trigger tag in Toolbar examples 

### DIFF
--- a/data/primitives/components/toolbar/0.1.5.mdx
+++ b/data/primitives/components/toolbar/0.1.5.mdx
@@ -326,7 +326,7 @@ export default () => (
     <Toolbar.Separator />
     <DropdownMenu.Root>
       <Toolbar.Button __asChild__>
-        <DropdownMenu.Trigger>Trigger<DropdownMenu.Trigger>
+        <DropdownMenu.Trigger>Trigger</DropdownMenu.Trigger>
       </Toolbar.Button>
       <DropdownMenu.Content>…</DropdownMenu.Content>
     </DropdownMenu.Root>


### PR DESCRIPTION
This pull request:
- [X] Updates documentation or example code
