### PR TITLE
Add missing event props to `Toast.Root`

### DIFF
--- a/data/primitives/components/toast/0.1.1.mdx
+++ b/data/primitives/components/toast/0.1.1.mdx
@@ -188,6 +188,50 @@ The toast that automatically closes. It should not be held open to [acquire a us
         'Event handler called when the open state of the dialog changes.',
     },
     {
+      name: 'onEscapeKeyDown',
+      type: '(event: KeyboardEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called when the escape key is down. It can be prevented
+          by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onSwipeStart',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called when starting a swipe interaction. It can be
+          prevented by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onSwipeMove',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called during a swipe interaction. It can be prevented
+          by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onSwipeEnd',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called at the end of a swipe interaction. It can be
+          prevented by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
       name: 'forceMount',
       type: 'boolean',
       description:

--- a/data/primitives/components/toast/1.0.0.mdx
+++ b/data/primitives/components/toast/1.0.0.mdx
@@ -204,6 +204,50 @@ The toast that automatically closes. It should not be held open to [acquire a us
         'Event handler called when the open state of the dialog changes.',
     },
     {
+      name: 'onEscapeKeyDown',
+      type: '(event: KeyboardEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called when the escape key is down. It can be prevented
+          by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onSwipeStart',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called when starting a swipe interaction. It can be
+          prevented by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onSwipeMove',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called during a swipe interaction. It can be prevented
+          by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
+      name: 'onSwipeEnd',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called at the end of a swipe interaction. It can be
+          prevented by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
       name: 'forceMount',
       type: 'boolean',
       description:


### PR DESCRIPTION
closes https://github.com/radix-ui/website/issues/445
