### PR TITLE
Add missing data-state to Toolbar component

### DIFF
--- a/data/primitives/components/toolbar/1.0.0.mdx
+++ b/data/primitives/components/toolbar/1.0.0.mdx
@@ -329,6 +329,10 @@ An item in the group.
       values: ['on', 'off'],
     },
     {
+      attribute: '[data-disabled]',
+      values: 'Present when disabled',
+    },
+    {
       attribute: '[data-orientation]',
       values: ['vertical', 'horizontal'],
     },

--- a/data/primitives/components/toolbar/1.0.0.mdx
+++ b/data/primitives/components/toolbar/1.0.0.mdx
@@ -325,6 +325,10 @@ An item in the group.
 <DataAttributesTable
   data={[
     {
+      attribute: '[data-on]',
+      values: ['on', 'off'],
+    }
+    {
       attribute: '[data-orientation]',
       values: ['vertical', 'horizontal'],
     },

--- a/data/primitives/components/toolbar/1.0.0.mdx
+++ b/data/primitives/components/toolbar/1.0.0.mdx
@@ -325,7 +325,7 @@ An item in the group.
 <DataAttributesTable
   data={[
     {
-      attribute: '[data-on]',
+      attribute: '[data-state]',
       values: ['on', 'off'],
     },
     {

--- a/data/primitives/components/toolbar/1.0.0.mdx
+++ b/data/primitives/components/toolbar/1.0.0.mdx
@@ -327,7 +327,7 @@ An item in the group.
     {
       attribute: '[data-on]',
       values: ['on', 'off'],
-    }
+    },
     {
       attribute: '[data-orientation]',
       values: ['vertical', 'horizontal'],


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

This pull request:

Adds the (I think missing) `data-state` `"on" | "off"` reference to the Toolbar ToggleItem documentation.

- [x] Updates documentation or example code
