### PR TITLE
[Search] Temporarily remove next link prefetch

### DIFF
--- a/algolia/config.json
+++ b/algolia/config.json
@@ -1,7 +1,7 @@
 {
   "index_name": "docs",
-  "start_urls": ["https://radix-ui.com/docs/primitives"],
-  "stop_urls": ["https://radix-ui.com/docs/primitives/overview/releases"],
+  "start_urls": ["https://www.radix-ui.com/docs/primitives"],
+  "stop_urls": ["https://www.radix-ui.com/docs/primitives/overview/releases"],
   "selectors": {
     "lvl0": { "selector": "[data-algolia-lvl0]", "global": true },
     "lvl1": "[data-algolia-page-scope] h1",

--- a/components/PrimitivesDocsSearch.tsx
+++ b/components/PrimitivesDocsSearch.tsx
@@ -9,7 +9,6 @@ import {
   CaretRightIcon,
 } from '@radix-ui/react-icons';
 import { RemoveScroll } from 'react-remove-scroll';
-import Link from 'next/link';
 import { Box, TextField, Panel, IconButton, Tooltip, Text, styled } from '@modulz/design-system';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { Slot } from '@radix-ui/react-slot';
@@ -437,19 +436,21 @@ const SearchResults = React.memo(
 
 function ItemLink({ item }: { item: SearchItem }) {
   return (
-    <Link href={item.url} passHref>
-      <Box as="a" css={{ display: 'block', p: '$2', textDecoration: 'none', color: 'inherit' }}>
-        <ItemTitle as="p" variant="violet" size="3" css={{ mb: '$1' }}>
-          <Highlight
-            hit={item}
-            attribute={item.type === 'content' ? 'content' : ['hierarchy', item.type]}
-          />
-        </ItemTitle>
-        {/* Adding a semi-colon to insert a break in the speech flow */}
-        <VisuallyHidden>; </VisuallyHidden>
-        <ItemBreadcrumb item={item} levels={SUPPORTED_LEVELS} />
-      </Box>
-    </Link>
+    <Box
+      href={item.url}
+      as="a"
+      css={{ display: 'block', p: '$2', textDecoration: 'none', color: 'inherit' }}
+    >
+      <ItemTitle as="p" variant="violet" size="3" css={{ mb: '$1' }}>
+        <Highlight
+          hit={item}
+          attribute={item.type === 'content' ? 'content' : ['hierarchy', item.type]}
+        />
+      </ItemTitle>
+      {/* Adding a semi-colon to insert a break in the speech flow */}
+      <VisuallyHidden>; </VisuallyHidden>
+      <ItemBreadcrumb item={item} levels={SUPPORTED_LEVELS} />
+    </Box>
   );
 }
 


### PR DESCRIPTION
Seems we need to do a bit more work with the URLs returned from Algolia as prefetching in production isn't working at the moment, they return 404s and the behaviour is falling back to absolute routing anyway.

Will look into it separately for now this should silence the console.