### PR TITLE
Enable client side routing in search hits (WIP)

### DIFF
--- a/components/PrimitivesDocsSearch.tsx
+++ b/components/PrimitivesDocsSearch.tsx
@@ -437,7 +437,7 @@ const SearchResults = React.memo(
 
 function ItemLink({ item }: { item: SearchItem }) {
   return (
-    <Link href={item.url} passHref>
+    <Link href={item.url} passHref prefetch={false}>
       <Box as="a" css={{ display: 'block', p: '$2', textDecoration: 'none', color: 'inherit' }}>
         <ItemTitle as="p" variant="violet" size="3" css={{ mb: '$1' }}>
           <Highlight

--- a/components/PrimitivesDocsSearch.tsx
+++ b/components/PrimitivesDocsSearch.tsx
@@ -9,6 +9,7 @@ import {
   CaretRightIcon,
 } from '@radix-ui/react-icons';
 import { RemoveScroll } from 'react-remove-scroll';
+import Link from 'next/link';
 import { Box, TextField, Panel, IconButton, Tooltip, Text, styled } from '@modulz/design-system';
 import { DismissableLayer } from '@radix-ui/react-dismissable-layer';
 import { Slot } from '@radix-ui/react-slot';
@@ -103,7 +104,7 @@ export function PrimitivesDocsSearch(props: PrimitivesDocsSearchProps) {
           return searchClient
             .search<SearchItem>([
               {
-                indexName: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME,
+                indexName: 'development_docs',
                 query,
                 params: {
                   hitsPerPage,
@@ -436,21 +437,19 @@ const SearchResults = React.memo(
 
 function ItemLink({ item }: { item: SearchItem }) {
   return (
-    <Box
-      href={item.url}
-      as="a"
-      css={{ display: 'block', p: '$2', textDecoration: 'none', color: 'inherit' }}
-    >
-      <ItemTitle as="p" variant="violet" size="3" css={{ mb: '$1' }}>
-        <Highlight
-          hit={item}
-          attribute={item.type === 'content' ? 'content' : ['hierarchy', item.type]}
-        />
-      </ItemTitle>
-      {/* Adding a semi-colon to insert a break in the speech flow */}
-      <VisuallyHidden>; </VisuallyHidden>
-      <ItemBreadcrumb item={item} levels={SUPPORTED_LEVELS} />
-    </Box>
+    <Link href={item.url} passHref>
+      <Box as="a" css={{ display: 'block', p: '$2', textDecoration: 'none', color: 'inherit' }}>
+        <ItemTitle as="p" variant="violet" size="3" css={{ mb: '$1' }}>
+          <Highlight
+            hit={item}
+            attribute={item.type === 'content' ? 'content' : ['hierarchy', item.type]}
+          />
+        </ItemTitle>
+        {/* Adding a semi-colon to insert a break in the speech flow */}
+        <VisuallyHidden>; </VisuallyHidden>
+        <ItemBreadcrumb item={item} levels={SUPPORTED_LEVELS} />
+      </Box>
+    </Link>
   );
 }
 


### PR DESCRIPTION
**Testing**

Prefetching only works in prod and only with absolute URLs when on the same origin. Prefetch 404 Issue appears to be that given an absolute url of:

`https://www.radix-ui.com/docs/primitives/components/avatar`

 the next/link prefetcher asks for

`(next data)/docs/primitives/components/avatar.json`

when it should be

`(next data)/docs/primitives/components/avatar/1.0.0.json`

which it can otherwise do if it were a relative path.