### PR TITLE
Edit invalid accessibility patterns urls

### DIFF
--- a/data/primitives/components/accordion/1.0.0.mdx
+++ b/data/primitives/components/accordion/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Accordion
 metaDescription: A vertically stacked set of interactive headings that each reveal an associated section of content.
 name: accordion
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#accordion
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/accordion/
 ---
 
 # Accordion
@@ -449,7 +449,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/alert-dialog/1.0.0.mdx
+++ b/data/primitives/components/alert-dialog/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Alert Dialog
 metaDescription: A modal dialog that interrupts the user with important content and expects a response.
 name: alert-dialog
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#alertdialog
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
 ---
 
 # Alert Dialog
@@ -364,7 +364,7 @@ export default () => {
 
 ## Accessibility
 
-Adheres to the [Alert and Message Dialogs WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#alertdialog).
+Adheres to the [Alert and Message Dialogs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/checkbox/1.0.0.mdx
+++ b/data/primitives/components/checkbox/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Checkbox
 metaDescription: A control that allows the user to toggle between checked and not checked.
 name: checkbox
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#checkbox
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
 ---
 
 # Checkbox
@@ -215,7 +215,7 @@ export default () => {
 
 ## Accessibility
 
-Adheres to the [tri-state Checkbox WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#checkbox).
+Adheres to the [tri-state Checkbox WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/collapsible/1.0.0.mdx
+++ b/data/primitives/components/collapsible/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Collapsible
 metaDescription: An interactive component which expands/collapses a panel.
 name: collapsible
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#disclosure
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/
 ---
 
 # Collapsible
@@ -226,7 +226,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Disclosure WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#disclosure).
+Adheres to the [Disclosure WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/1.0.0.mdx
+++ b/data/primitives/components/context-menu/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Context Menu
 metaDescription: Displays a menu located at the pointer, triggered by a right-click or a long-press.
 name: context-menu
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#menu
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/menu/
 ---
 
 # Context Menu
@@ -89,7 +89,7 @@ export default () => (
 
 ## API Reference
 
-Adheres to the [Menu WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#menu) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/menu-button/menu-button-actions.html) to manage focus movement among menu items.
+Adheres to the [Menu WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu/) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/menu-button/menu-button-actions.html) to manage focus movement among menu items.
 
 ### Root
 

--- a/data/primitives/components/dialog/1.0.0.mdx
+++ b/data/primitives/components/dialog/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#dialog_modal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
 ---
 
 # Dialog
@@ -473,7 +473,7 @@ export default () => {
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#dialog_modal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/1.0.0.mdx
+++ b/data/primitives/components/dropdown-menu/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dropdown Menu
 metaDescription: Displays a menu to the user—such as a set of actions or functions—triggered by a button.
 name: dropdown-menu
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#menubutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/
 ---
 
 # Dropdown Menu
@@ -1397,7 +1397,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#menubutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/#kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/popover/1.0.0.mdx
+++ b/data/primitives/components/popover/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#dialog_modal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
 ---
 
 # Popover
@@ -579,7 +579,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#dialog_modal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/radio-group/1.0.0.mdx
+++ b/data/primitives/components/radio-group/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton/
 ---
 
 # Radio Group
@@ -239,7 +239,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton/) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/select/1.0.0.mdx
+++ b/data/primitives/components/select/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Select
 metaDescription: Displays a list of options for the user to pick from—triggered by a button.
 name: select
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
 ---
 
 # Select
@@ -746,7 +746,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [ListBox WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox).
+Adheres to the [ListBox WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/).
 
 See the W3C [Select-Only Combobox](https://www.w3.org/TR/wai-aria-practices/examples/combobox/combobox-select-only.html) example for more information.
 

--- a/data/primitives/components/slider/1.0.0.mdx
+++ b/data/primitives/components/slider/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Slider
 metaDescription: An input where the user selects a value from within a given range.
 name: slider
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#slidertwothumb
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/
 ---
 
 # Slider
@@ -348,7 +348,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#slidertwothumb).
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/tabs/1.0.0.mdx
+++ b/data/primitives/components/tabs/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that are displayed one at a time.
 name: tabs
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 ---
 
 # Tabs
@@ -302,7 +302,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.2/#tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/).
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/toggle-group/1.0.0.mdx
+++ b/data/primitives/components/toggle-group/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Toggle Group
 metaDescription: A set of two-state buttons that can be toggled on or off.
 name: toggle-group
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#button
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 ---
 
 # Toggle Group

--- a/data/primitives/components/toggle/1.0.0.mdx
+++ b/data/primitives/components/toggle/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Toggle
 metaDescription: A two-state button that can be either on or off.
 name: toggle
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#button
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/button/
 ---
 
 # Toggle

--- a/data/primitives/components/toolbar/1.0.0.mdx
+++ b/data/primitives/components/toolbar/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Toolbar
 metaDescription: A container for grouping a set of controls, such as buttons, toggle groups or dropdown menus.
 name: toolbar
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#toolbar
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/
 ---
 
 # Toolbar

--- a/data/primitives/components/tooltip/1.0.0.mdx
+++ b/data/primitives/components/tooltip/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tooltip
 metaDescription: A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
 name: tooltip
-aria: https://www.w3.org/TR/wai-aria-practices-1.2/#tooltip
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/
 ---
 
 # Tooltip


### PR DESCRIPTION
Several urls about accessibility patterns were invalid in the documentation. I replaced these urls with the good ones!

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

Closes #403 