### PR TITLE
Fix wrong casing in context menu docs

### DIFF
--- a/data/primitives/components/context-menu/1.0.0.mdx
+++ b/data/primitives/components/context-menu/1.0.0.mdx
@@ -54,7 +54,7 @@ export default () => (
   <ContextMenu.Root>
     <ContextMenu.Trigger />
 
-    <Contextmenu.Portal>
+    <ContextMenu.Portal>
       <ContextMenu.Content>
         <ContextMenu.Label />
         <ContextMenu.Item />
@@ -82,7 +82,7 @@ export default () => (
 
         <ContextMenu.Separator />
       </ContextMenu.Content>
-    </Contextmenu.Portal>
+    </ContextMenu.Portal>
   </ContextMenu.Root>
 );
 ```


### PR DESCRIPTION
Fix small typo in context menu documentation

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
