### PR TITLE
[Select] Add `disabled` to API Reference

### DIFF
--- a/data/primitives/components/select/1.1.0.mdx
+++ b/data/primitives/components/select/1.1.0.mdx
@@ -11,6 +11,14 @@ aria: https://www.w3.org/WAI/ARIA/apg/patterns/listbox
   Displays a list of options for the user to pick from—triggered by a button.
 </Description>
 
+<HeroContainer>
+  <SelectDemo />
+</HeroContainer>
+
+```jsx hero template=Select
+
+```
+
 <Highlights
   features={[
     'Can be controlled or uncontrolled.',

--- a/data/primitives/components/select/1.1.0.mdx
+++ b/data/primitives/components/select/1.1.0.mdx
@@ -157,6 +157,16 @@ Contains all the parts of a select.
       description:
         'The name of the select. Submitted with its owning form as part of a name/value pair.',
     },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      description: (
+        <span>
+          When <Code>true</Code>, prevents the user from interacting with
+          select.
+        </span>
+      ),
+    },
   ]}
 />
 

--- a/data/primitives/overview/releases.mdx
+++ b/data/primitives/overview/releases.mdx
@@ -41,6 +41,10 @@ metaDescription: Radix Primitives releases and their changelogs.
 - Add `disabled` prop to `RadioGroup.Root` <PRLink id={1530} />
 - Fix issue where `RadioGroup.Root` was focusable when all items were disabled <PRLink id={1530} />
 
+<PackageRelease name="Select" version="1.1.0" />
+
+- Add `disabled` prop to `Select.Root` <PRLink id={1699} />
+
 <PackageRelease name="Slider" version="1.1.0" />
 
 - Add ability to visually invert the slider using the new `inverted` prop on `Slider.Root` <PRLink id={1695} />


### PR DESCRIPTION
Document the `disabled` prop in API Reference (Merge after [this PR](https://github.com/radix-ui/primitives/pull/1699) merged)

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [X] Updates documentation or example code
- [ ] Other
