### PR TITLE
Fix spacing between elements on website's nav menu

### DIFF
--- a/components/DocsNav.tsx
+++ b/components/DocsNav.tsx
@@ -42,6 +42,9 @@ export function NavItem({ children, active, disabled, href, ...props }: NavItemP
           minHeight: '$6',
           transition: 'background-color 50ms linear',
           ...(disabled ? { pointerEvents: 'none' } : {}),
+          '&:not(:last-of-type)': {
+            mb: '$1',
+          },
           '&:hover': {
             backgroundColor: active ? '$violet5' : '$violet4',
           },

--- a/components/DocsNav.tsx
+++ b/components/DocsNav.tsx
@@ -43,14 +43,14 @@ export function NavItem({ children, active, disabled, href, ...props }: NavItemP
           transition: 'background-color 50ms linear',
           ...(disabled ? { pointerEvents: 'none' } : {}),
           '&:not(:last-of-type)': {
-            mb: '$1',
+            mb: 1,
           },
           '&:hover': {
             backgroundColor: active ? '$violet5' : '$violet4',
           },
           '&:focus': {
             outline: 'none',
-            boxShadow: '0 0 0 1px $colors$violet7',
+            boxShadow: 'inset 0 0 1px $colors$violet7',
           },
         }}
       >

--- a/components/DocsNav.tsx
+++ b/components/DocsNav.tsx
@@ -50,7 +50,7 @@ export function NavItem({ children, active, disabled, href, ...props }: NavItemP
           },
           '&:focus': {
             outline: 'none',
-            boxShadow: 'inset 0 0 1px $colors$violet7',
+            boxShadow: 'inset 0 0 0 1px $colors$violet7',
           },
         }}
       >


### PR DESCRIPTION
I'm not sure if this is a PR that you might agree with but while navigating the website I noticed that the navigation items were very close to each other and there was an overlapping issue between the current selected item and the previous/next ones.
To prevent this I've added some spacing between items by checking if it's the last item in the section

---

**Before**

https://user-images.githubusercontent.com/30603437/195714008-4c6f650a-b07c-44cb-8613-e8299274daf0.mp4

**After**

https://user-images.githubusercontent.com/30603437/195714220-872e1949-f3bb-4722-87ec-e54048641923.mp4

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
