### PR TITLE
Tweak expand UI

### DIFF
--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -204,7 +204,7 @@ export const HeroCodeBlock = ({ children }: { children?: React.ReactNode }) => {
                         borderTopLeftRadius: 0,
                         borderTopRightRadius: 0,
                         maxHeight: isCodeExpanded ? '80vh' : 150,
-                        paddingBottom: isCodeExpanded ? '$8' : undefined,
+                        paddingBottom: isCodeExpanded ? '$9' : undefined,
                       }}
                     >
                       <code>{tab.children}</code>

--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -223,13 +223,24 @@ export const HeroCodeBlock = ({ children }: { children?: React.ReactNode }) => {
                 height: '$9',
                 width: '100%',
                 padding: '$2',
-                background: 'linear-gradient(180deg, transparent, $colors$violet2 70%)',
+                overflow: 'hidden',
                 borderRadius: '0 0 $3 $3',
+                '&::before': {
+                  content: '',
+                  display: 'block',
+                  width: '100%',
+                  height: '100%',
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  background: 'linear-gradient(180deg, transparent, $colors$violet2 70%)',
+                  opacity: 0.9,
+                },
               }}
               justify="center"
             >
               <Collapsible.Trigger asChild>
-                <Button>{isCodeExpanded ? 'Collapse' : 'Expand'} code</Button>
+                <Button css={{ zIndex: 1 }}>{isCodeExpanded ? 'Collapse' : 'Expand'} code</Button>
               </Collapsible.Trigger>
             </Flex>
           </Box>

--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -194,7 +194,7 @@ export const HeroCodeBlock = ({ children }: { children?: React.ReactNode }) => {
                       borderBottomRightRadius: '$3',
                       '&:focus': {
                         outline: 'none',
-                        boxShadow: '0 0 0 2px $colors$violet7',
+                        boxShadow: '0 0 0 2px $colors$violetA7',
                       },
                     }}
                   >
@@ -203,7 +203,8 @@ export const HeroCodeBlock = ({ children }: { children?: React.ReactNode }) => {
                       css={{
                         borderTopLeftRadius: 0,
                         borderTopRightRadius: 0,
-                        maxHeight: isCodeExpanded ? 600 : 100,
+                        maxHeight: isCodeExpanded ? '80vh' : 150,
+                        paddingBottom: isCodeExpanded ? '$8' : undefined,
                       }}
                     >
                       <code>{tab.children}</code>
@@ -215,20 +216,20 @@ export const HeroCodeBlock = ({ children }: { children?: React.ReactNode }) => {
             </Tabs.Root>
 
             <Flex
+              align="end"
               css={{
                 position: 'absolute',
                 bottom: 0,
+                height: '$9',
                 width: '100%',
                 padding: '$2',
-                background: 'linear-gradient(180deg, transparent, $colors$violet2)',
-                borderRadius: '0 0 $2 $2',
+                background: 'linear-gradient(180deg, transparent, $colors$violet2 70%)',
+                borderRadius: '0 0 $3 $3',
               }}
               justify="center"
             >
               <Collapsible.Trigger asChild>
-                <Button ghost css={{}}>
-                  {isCodeExpanded ? 'Collapse' : 'Expand'} code
-                </Button>
+                <Button>{isCodeExpanded ? 'Collapse' : 'Expand'} code</Button>
               </Collapsible.Trigger>
             </Flex>
           </Box>


### PR DESCRIPTION
Worked with @vladmoroz to improve the accessibility/ui for collapsing/expanding the code.

<img width="962" alt="CleanShot 2022-11-04 at 11 42 28@2x" src="https://user-images.githubusercontent.com/1539897/199964580-83bae088-145a-4f48-a4de-021816320dd5.png">
