### PR TITLE
Fix typo in Dialog demo CSS

### DIFF
--- a/components/demos/Dialog/css/styles.css
+++ b/components/demos/Dialog/css/styles.css
@@ -146,7 +146,7 @@ input {
 @keyframes contentShow {
   from {
     opacity: 0;
-    opacity: translate(-50%, -48%) scale(0.96);
+    transform: translate(-50%, -48%) scale(0.96);
   }
   to {
     opacity: 1;


### PR DESCRIPTION
Fix typo — `opacity` to `transform`.
