### PR TITLE
[Dialog][AlertDialog] Fix async examples

### DIFF
--- a/data/primitives/components/alert-dialog/1.0.2.mdx
+++ b/data/primitives/components/alert-dialog/1.0.2.mdx
@@ -341,32 +341,31 @@ An accessible description to be announced when the dialog is opened. Alternative
 
 Use the controlled props to programmatically close the Alert Dialog after an async operation has completed.
 
-```jsx
+```jsx line=4,7,10,15,17
 import React from 'react';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 
-const mockPromise = async () =>
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+const wait = () => new Promise((resolve) => setTimeout(resolve, 1000));
 
 export default () => {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <AlertDialog.Root open={open} onOpenChange={setOpen}>
-      <AlertDialog.Trigger />
+    <AlertDialog.Root __open__={open} __onOpenChange__={setOpen}>
+      <AlertDialog.Trigger>Open</AlertDialog.Trigger>
       <AlertDialog.Portal>
-        <AlertDialog.Overlay>
-          <AlertDialog.Content>
-            <form
-              onSubmit={async () => {
-                mockPromise().then(() => setOpen(false));
-              }}
-            >
-              {/** some inputs */}
-              <AlertDialog.Action type="submit">Submit</AlertDialog.Action>
-            </form>
-          </AlertDialog.Content>
-        </AlertDialog.Overlay>
+        <AlertDialog.Overlay />
+        <AlertDialog.Content>
+          <form
+            onSubmit={(event) => {
+              wait().then(() => setOpen(false));
+              event.preventDefault();
+            }}
+          >
+            {/** some inputs */}
+            <button type="submit">Submit</button>
+          </form>
+        </AlertDialog.Content>
       </AlertDialog.Portal>
     </AlertDialog.Root>
   );

--- a/data/primitives/components/dialog/1.0.2.mdx
+++ b/data/primitives/components/dialog/1.0.2.mdx
@@ -372,32 +372,31 @@ If you want to hide the description, wrap it inside our [Visually Hidden](../uti
 
 Use the controlled props to programmatically close the Dialog after an async operation has completed.
 
-```jsx
+```jsx line=4,7,10,15,17
 import React from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 
-const mockPromise = async () =>
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+const wait = () => new Promise((resolve) => setTimeout(resolve, 1000));
 
 export default () => {
   const [open, setOpen] = React.useState(false);
 
   return (
-    <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Trigger />
+    <Dialog.Root __open__={open} __onOpenChange__={setOpen}>
+      <Dialog.Trigger>Open</Dialog.Trigger>
       <Dialog.Portal>
-        <Dialog.Overlay>
-          <Dialog.Content>
-            <form
-              onSubmit={async () => {
-                mockPromise().then(() => setOpen(false));
-              }}
-            >
-              {/** some inputs */}
-              <button type="submit">Submit</button>
-            </form>
-          </Dialog.Content>
-        </Dialog.Overlay>
+        <Dialog.Overlay />
+        <Dialog.Content>
+          <form
+            onSubmit={(event) => {
+              wait().then(() => setOpen(false));
+              event.preventDefault();
+            }}
+          >
+            {/** some inputs */}
+            <button type="submit">Submit</button>
+          </form>
+        </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
   );


### PR DESCRIPTION
I've also pared down on async/await to make things simpler and not add more potential confusion.