### PR TITLE
Fix: Wrong Accordion Item link (/docs/primitives/overview/styling)

### DIFF
--- a/data/primitives/overview/styling.mdx
+++ b/data/primitives/overview/styling.mdx
@@ -22,7 +22,7 @@ All components and their parts accept a `className` prop. This class will be pas
 
 ### Data attributes
 
-When components are stateful, their state will be exposed in a `data-state` attribute. For example, when an [Accordion Item](../components/dialog) is opened, it includes a `data-state="open"` attribute.
+When components are stateful, their state will be exposed in a `data-state` attribute. For example, when an [Accordion Item](../components/accordion) is opened, it includes a `data-state="open"` attribute.
 
 ## Styling with CSS
 


### PR DESCRIPTION
https://www.radix-ui.com/docs/primitives/overview/styling#data-attributes

In Styling documentation, Accordion Item url is invalid, so I modified it.

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other