### PR TITLE
Added media query to ScrollAreaThumb in ScrollArea component

### DIFF
--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -242,11 +242,12 @@ export const HeroCodeBlock = ({
                 bottom: 0,
                 height: '$9',
                 width: '100%',
-                padding: '$2',
+                padding: '$3',
                 overflow: 'hidden',
                 borderRadius: '0 0 $3 $3',
                 '&::before': {
                   content: '',
+                  pointerEvents: 'none',
                   display: 'block',
                   width: '100%',
                   height: '100%',

--- a/components/ScrollArea.tsx
+++ b/components/ScrollArea.tsx
@@ -63,18 +63,16 @@ const ScrollAreaThumb = styled(ScrollAreaPrimitive.Thumb, {
   zIndex: 1,
   // increase target size for touch devices https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
   position: 'relative',
-  '@media (hover: none)': {
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
-      width: '100%',
-      height: '100%',
-      minWidth: 44,
-      minHeight: 44,
-    },
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: '100%',
+    height: '100%',
+    minWidth: 44,
+    minHeight: 44,
   },
 });
 

--- a/components/ScrollArea.tsx
+++ b/components/ScrollArea.tsx
@@ -63,16 +63,18 @@ const ScrollAreaThumb = styled(ScrollAreaPrimitive.Thumb, {
   zIndex: 1,
   // increase target size for touch devices https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
   position: 'relative',
-  '&::before': {
-    content: '""',
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    width: '100%',
-    height: '100%',
-    minWidth: 44,
-    minHeight: 44,
+  '@media (hover: none)': {
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      width: '100%',
+      height: '100%',
+      minWidth: 44,
+      minHeight: 44,
+    },
   },
 });
 


### PR DESCRIPTION
Why I added this little piece of media query: if you go to the docs in some block of code that contains the horizontal scrollbar (e.g [navigation menu](https://www.radix-ui.com/docs/primitives/components/navigation-menu)), you will notice that it is difficult to click on the "Collapse code" button when the scrollbar is visible, to do that, you need to click in the extreme top of the button. 

In the video i'm clicking in the button and you will notice that the code don't collapse, then i'm sliding the scroll because the scroll is above the button and then i'm clicking in the top of button to collapse.

[collapse-button.webm](https://user-images.githubusercontent.com/58708551/207613977-5b23fe88-8260-452f-b21c-e1e039c9c152.webm)


I noticed that the piece of code that made this happen is the height and width of the scroll thumb. I also noticed that a developer inserted a comment into this part of the code that says:

 // increase target size for touch devices https://www.w3.org/WAI/WCAG21/Understanding/target-size.html

If it is to increase the size for better accessibility on touch devices, then I thought it might be better to add a media query that detects if the device is touch. I did a search on stackoverflow and found that the media query "hover: none" does this, since touch devices do not have the hover event.

I also found another problem, for the horizontal bar, the scroll **_track_** doesn't work, while for the vertical bar it works normally, but not in the area of the element that is above the scrollbar (the collapse button container). If you try to click on the track you end up clicking on that element. I thought about adding a zIndex to the track, but I didn't find the scroll track primitive to do that, it would be nice if there was a primitive for the scroll track.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
