### PR TITLE
[POC][Accordion] Add tailwind CSS support

### DIFF
--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -24,6 +24,7 @@ export const HeroCodeBlock = ({
   const [preferredCssLib, setPreferredCssLib] = useCssLibPreference();
   const usedCssLib = cssLibProp ?? preferredCssLib;
   const [isCodeExpanded, setIsCodeExpanded] = React.useState(false);
+  const module = usedCssLib === 'tailwind' ? 'App.jsx' : 'App.js';
 
   const snippets = React.Children.toArray(children).map((pre) => {
     if (pre && typeof pre === 'object' && 'props' in pre) {
@@ -79,7 +80,7 @@ export const HeroCodeBlock = ({
             method="POST"
             target="_blank"
           >
-            <input type="hidden" name="query" value="module=App.js" />
+            <input type="hidden" name="query" value={`module=${module}`} />
             <input
               type="hidden"
               name="parameters"

--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -80,7 +80,13 @@ export const HeroCodeBlock = ({
             method="POST"
             target="_blank"
           >
-            <input type="hidden" name="query" value={`module=${module}`} />
+            <input type="hidden" name="query" value={`file=/${module}`} />
+            {usedCssLib === 'tailwind' && (
+              <>
+                <input type="hidden" name="environment" value="server" />
+                <input type="hidden" name="hidedevtools" value="1" />
+              </>
+            )}
             <input
               type="hidden"
               name="parameters"

--- a/components/demos/Accordion/tailwind/index.jsx
+++ b/components/demos/Accordion/tailwind/index.jsx
@@ -48,7 +48,7 @@ const AccordionTrigger = React.forwardRef(({ children, className, ...props }, fo
   <Accordion.Header className="flex">
     <Accordion.Trigger
       className={classNames(
-        'text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-white px-5 text-[15px] leading-none shadow-[0_1px_0]',
+        'text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-white px-5 text-[15px] leading-none shadow-[0_1px_0] outline-none',
         className
       )}
       {...props}

--- a/components/demos/Accordion/tailwind/index.jsx
+++ b/components/demos/Accordion/tailwind/index.jsx
@@ -48,7 +48,7 @@ const AccordionTrigger = React.forwardRef(({ children, className, ...props }, fo
   <Accordion.Header className="flex">
     <Accordion.Trigger
       className={classNames(
-        'text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-transparent bg-white px-5 text-[15px] leading-none shadow-[0_1px_0]',
+        'text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-white px-5 text-[15px] leading-none shadow-[0_1px_0]',
         className
       )}
       {...props}

--- a/components/demos/Accordion/tailwind/index.jsx
+++ b/components/demos/Accordion/tailwind/index.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import classNames from 'classnames';
+import * as Accordion from '@radix-ui/react-accordion';
+import { ChevronDownIcon } from '@radix-ui/react-icons';
+
+const AccordionDemo = () => (
+  <Accordion.Root
+    className="rounded-md w-[300px] bg-mauve6 shadow-[0_2px_10px] shadow-black/5"
+    type="single"
+    defaultValue="item-1"
+    collapsible
+  >
+    <AccordionItem value="item-1">
+      <AccordionTrigger>Is it accessible?</AccordionTrigger>
+      <AccordionContent>Yes. It adheres to the WAI-ARIA design pattern.</AccordionContent>
+    </AccordionItem>
+
+    <AccordionItem value="item-2">
+      <AccordionTrigger>Is it unstyled?</AccordionTrigger>
+      <AccordionContent>
+        Yes. It's unstyled by default, giving you freedom over the look and feel.
+      </AccordionContent>
+    </AccordionItem>
+
+    <AccordionItem value="item-3">
+      <AccordionTrigger>Can it be animated?</AccordionTrigger>
+      <AccordionContent>
+        Yes! You can animate the Accordion with CSS or JavaScript.
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion.Root>
+);
+
+const AccordionItem = React.forwardRef(({ children, className, ...props }, forwardedRef) => (
+  <Accordion.Item
+    className={classNames(
+      'overflow-hidden mt-px first:mt-0 first:rounded-t last:rounded-b focus-within:relative focus-within:z-10 focus-within:shadow-[0_0_0_2px] focus-within:shadow-mauve12',
+      className
+    )}
+    {...props}
+    ref={forwardedRef}
+  >
+    {children}
+  </Accordion.Item>
+));
+
+const AccordionTrigger = React.forwardRef(({ children, className, ...props }, forwardedRef) => (
+  <Accordion.Header className="flex">
+    <Accordion.Trigger
+      className={classNames(
+        'bg-transparent px-5 h-[45px] flex-1 flex items-center justify-between text-[15px] leading-none text-violet11 bg-white shadow-[0_1px_0] shadow-mauve6 hover:bg-mauve2 group',
+        className
+      )}
+      {...props}
+      ref={forwardedRef}
+    >
+      {children}
+      <ChevronDownIcon
+        className="text-violet10 transition-transform duration-300 ease-[cubic-bezier(0.87, 0, 0.13, 1)] group-data-[state=open]:rotate-180"
+        aria-hidden
+      />
+    </Accordion.Trigger>
+  </Accordion.Header>
+));
+
+const AccordionContent = React.forwardRef(({ children, className, ...props }, forwardedRef) => (
+  <Accordion.Content
+    className={classNames(
+      'overflow-hidden text-[15px] text-mauve11 bg-mauve2 data-[state=open]:animate-slideDown data-[state=closed]:animate-slideUp',
+      className
+    )}
+    {...props}
+    ref={forwardedRef}
+  >
+    <div className="py-[15px] px-5">{children}</div>
+  </Accordion.Content>
+));
+
+export default AccordionDemo;

--- a/components/demos/Accordion/tailwind/index.jsx
+++ b/components/demos/Accordion/tailwind/index.jsx
@@ -5,7 +5,7 @@ import { ChevronDownIcon } from '@radix-ui/react-icons';
 
 const AccordionDemo = () => (
   <Accordion.Root
-    className="rounded-md w-[300px] bg-mauve6 shadow-[0_2px_10px] shadow-black/5"
+    className="bg-mauve6 w-[300px] rounded-md shadow-[0_2px_10px] shadow-black/5"
     type="single"
     defaultValue="item-1"
     collapsible
@@ -34,7 +34,7 @@ const AccordionDemo = () => (
 const AccordionItem = React.forwardRef(({ children, className, ...props }, forwardedRef) => (
   <Accordion.Item
     className={classNames(
-      'overflow-hidden mt-px first:mt-0 first:rounded-t last:rounded-b focus-within:relative focus-within:z-10 focus-within:shadow-[0_0_0_2px] focus-within:shadow-mauve12',
+      'focus-within:shadow-mauve12 mt-px overflow-hidden first:mt-0 first:rounded-t last:rounded-b focus-within:relative focus-within:z-10 focus-within:shadow-[0_0_0_2px]',
       className
     )}
     {...props}
@@ -48,7 +48,7 @@ const AccordionTrigger = React.forwardRef(({ children, className, ...props }, fo
   <Accordion.Header className="flex">
     <Accordion.Trigger
       className={classNames(
-        'bg-transparent px-5 h-[45px] flex-1 flex items-center justify-between text-[15px] leading-none text-violet11 bg-white shadow-[0_1px_0] shadow-mauve6 hover:bg-mauve2 group',
+        'text-violet11 shadow-mauve6 hover:bg-mauve2 group flex h-[45px] flex-1 cursor-default items-center justify-between bg-transparent bg-white px-5 text-[15px] leading-none shadow-[0_1px_0]',
         className
       )}
       {...props}
@@ -56,7 +56,7 @@ const AccordionTrigger = React.forwardRef(({ children, className, ...props }, fo
     >
       {children}
       <ChevronDownIcon
-        className="text-violet10 transition-transform duration-300 ease-[cubic-bezier(0.87, 0, 0.13, 1)] group-data-[state=open]:rotate-180"
+        className="text-violet10 ease-[cubic-bezier(0.87, 0, 0.13, 1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
         aria-hidden
       />
     </Accordion.Trigger>
@@ -66,7 +66,7 @@ const AccordionTrigger = React.forwardRef(({ children, className, ...props }, fo
 const AccordionContent = React.forwardRef(({ children, className, ...props }, forwardedRef) => (
   <Accordion.Content
     className={classNames(
-      'overflow-hidden text-[15px] text-mauve11 bg-mauve2 data-[state=open]:animate-slideDown data-[state=closed]:animate-slideUp',
+      'text-mauve11 bg-mauve2 data-[state=open]:animate-slideDown data-[state=closed]:animate-slideUp overflow-hidden text-[15px]',
       className
     )}
     {...props}

--- a/components/demos/Accordion/tailwind/tailwind.config.js
+++ b/components/demos/Accordion/tailwind/tailwind.config.js
@@ -1,34 +1,13 @@
+const { mauve, violet } = require('@radix-ui/colors');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./App.jsx'],
   theme: {
     extend: {
       colors: {
-        mauve1: 'hsl(300, 20.0%, 99.0%)',
-        mauve2: 'hsl(300, 7.7%, 97.5%)',
-        mauve3: 'hsl(294, 5.5%, 95.3%)',
-        mauve4: 'hsl(289, 4.7%, 93.3%)',
-        mauve5: 'hsl(283, 4.4%, 91.3%)',
-        mauve6: 'hsl(278, 4.1%, 89.1%)',
-        mauve7: 'hsl(271, 3.9%, 86.3%)',
-        mauve8: 'hsl(255, 3.7%, 78.8%)',
-        mauve9: 'hsl(252, 4.0%, 57.3%)',
-        mauve10: 'hsl(253, 3.5%, 53.5%)',
-        mauve11: 'hsl(252, 4.0%, 44.8%)',
-        mauve12: 'hsl(260, 25.0%, 11.0%)',
-
-        violet1: 'hsl(255, 65.0%, 99.4%)',
-        violet2: 'hsl(252, 100%, 99.0%)',
-        violet3: 'hsl(252, 96.9%, 97.4%)',
-        violet4: 'hsl(252, 91.5%, 95.5%)',
-        violet5: 'hsl(252, 85.1%, 93.0%)',
-        violet6: 'hsl(252, 77.8%, 89.4%)',
-        violet7: 'hsl(252, 71.0%, 83.7%)',
-        violet8: 'hsl(252, 68.6%, 76.3%)',
-        violet9: 'hsl(252, 56.0%, 57.5%)',
-        violet10: 'hsl(251, 48.1%, 53.5%)',
-        violet11: 'hsl(250, 43.0%, 48.0%)',
-        violet12: 'hsl(254, 60.0%, 18.5%)',
+        ...mauve,
+        ...violet,
       },
       keyframes: {
         slideDown: {

--- a/components/demos/Accordion/tailwind/tailwind.config.js
+++ b/components/demos/Accordion/tailwind/tailwind.config.js
@@ -1,0 +1,50 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./App.jsx'],
+  theme: {
+    extend: {
+      colors: {
+        mauve1: 'hsl(300, 20.0%, 99.0%)',
+        mauve2: 'hsl(300, 7.7%, 97.5%)',
+        mauve3: 'hsl(294, 5.5%, 95.3%)',
+        mauve4: 'hsl(289, 4.7%, 93.3%)',
+        mauve5: 'hsl(283, 4.4%, 91.3%)',
+        mauve6: 'hsl(278, 4.1%, 89.1%)',
+        mauve7: 'hsl(271, 3.9%, 86.3%)',
+        mauve8: 'hsl(255, 3.7%, 78.8%)',
+        mauve9: 'hsl(252, 4.0%, 57.3%)',
+        mauve10: 'hsl(253, 3.5%, 53.5%)',
+        mauve11: 'hsl(252, 4.0%, 44.8%)',
+        mauve12: 'hsl(260, 25.0%, 11.0%)',
+
+        violet1: 'hsl(255, 65.0%, 99.4%)',
+        violet2: 'hsl(252, 100%, 99.0%)',
+        violet3: 'hsl(252, 96.9%, 97.4%)',
+        violet4: 'hsl(252, 91.5%, 95.5%)',
+        violet5: 'hsl(252, 85.1%, 93.0%)',
+        violet6: 'hsl(252, 77.8%, 89.4%)',
+        violet7: 'hsl(252, 71.0%, 83.7%)',
+        violet8: 'hsl(252, 68.6%, 76.3%)',
+        violet9: 'hsl(252, 56.0%, 57.5%)',
+        violet10: 'hsl(251, 48.1%, 53.5%)',
+        violet11: 'hsl(250, 43.0%, 48.0%)',
+        violet12: 'hsl(254, 60.0%, 18.5%)',
+      },
+      keyframes: {
+        slideDown: {
+          from: { height: 0 },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        slideUp: {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: 0 },
+        },
+      },
+      animation: {
+        slideDown: 'slideDown 300ms cubic-bezier(0.87, 0, 0.13, 1)',
+        slideUp: 'slideUp 300ms cubic-bezier(0.87, 0, 0.13, 1)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,11 +1,12 @@
 const DEFAULT_CSS_LIB = 'css';
-const SUPPORTED_CSS_LIBS = [DEFAULT_CSS_LIB, 'stitches'] as const;
+const SUPPORTED_CSS_LIBS = [DEFAULT_CSS_LIB, 'stitches', 'tailwind'] as const;
 
 type CssLib = typeof SUPPORTED_CSS_LIBS[number];
 
 const CSS_LIB_NAMES: Record<CssLib, string> = {
   css: 'CSS',
   stitches: 'Stitches',
+  tailwind: 'Tailwind CSS',
 };
 
 export { DEFAULT_CSS_LIB, SUPPORTED_CSS_LIBS, CSS_LIB_NAMES };

--- a/lib/rehype-hero-code-block.ts
+++ b/lib/rehype-hero-code-block.ts
@@ -14,10 +14,10 @@ const rehypeHeroCodeBlock = () => (tree: UnistTree) => {
         node.children = [];
 
         SUPPORTED_CSS_LIBS.forEach((lib) => {
-          ['index.jsx', 'styles.css'].forEach((file) => {
+          ['index.jsx', 'styles.css', 'tailwind.config.js'].forEach((file) => {
             const filePath = `${process.cwd()}/components/demos/${folder}/${lib}/${file}`;
             if (fileExists(filePath)) {
-              const [, extension] = file.split('.');
+              const [extension] = file.split('.').slice(-1);
               const syntax = getSyntax(extension);
               let source = fs.readFileSync(path.join(filePath), 'utf8');
 

--- a/lib/rehype-hero-code-block.ts
+++ b/lib/rehype-hero-code-block.ts
@@ -17,7 +17,7 @@ const rehypeHeroCodeBlock = () => (tree: UnistTree) => {
           ['index.jsx', 'styles.css', 'tailwind.config.js'].forEach((file) => {
             const filePath = `${process.cwd()}/components/demos/${folder}/${lib}/${file}`;
             if (fileExists(filePath)) {
-              const [extension] = file.split('.').slice(-1);
+              const extension = file.split('.').pop();
               const syntax = getSyntax(extension);
               let source = fs.readFileSync(path.join(filePath), 'utf8');
 


### PR DESCRIPTION
Some points

- I wasn't able to use `create-react-app` as template on codesandbox to run tailwindcss so I had to use `vite`. If you guys have any idea how to setup with `create-react-app` I appreciate
- I think we can put the space too that is used in demos in `tailwind.config.js`. I don't know if is too much for the user to copy?

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
