### PR TITLE
Fix wobbly homepage components

### DIFF
--- a/components/marketing/MainHeroDropdownMenu.tsx
+++ b/components/marketing/MainHeroDropdownMenu.tsx
@@ -22,6 +22,15 @@ const contentCss = {
   boxShadow: '0px 5px 30px -5px rgba(0, 0, 0, 0.1), 0 1px 3px -1px rgba(0, 0, 0, 0.2)',
 };
 
+const DropdownMenuContentWrapper = styled('div', {
+  // The default `position: fixed` is wobbly when scrolling with Mac touchpads,
+  // which is OK when using components for real, but looks awkward in the demos.
+  // `position: absolute` stays put as you scroll.
+  '& [data-radix-popper-content-wrapper]': {
+    position: 'absolute !important',
+  },
+});
+
 const DropdownMenuContent: any = styled(DropdownMenuPrimitive.Content, contentCss);
 
 const DropdownMenuSeparator = styled(DropdownMenuPrimitive.Separator, {
@@ -85,71 +94,80 @@ export function MainHeroDropdownMenu() {
         </DemoButton>
       </DropdownMenuPrimitive.Trigger>
 
-      <DropdownMenuContent
-        ref={contentRef}
-        sideOffset={5}
-        avoidCollisions={false}
-        onEscapeKeyDown={(event) => {
-          event.preventDefault();
-          if (event.target instanceof HTMLElement && contentRef.current?.contains(event.target)) {
-            setOpen(false);
-          }
-        }}
-        onInteractOutside={(event) => {
-          if (event.target !== triggerRef.current) {
+      <DropdownMenuContentWrapper>
+        <DropdownMenuContent
+          ref={contentRef}
+          sideOffset={5}
+          avoidCollisions={false}
+          onEscapeKeyDown={(event) => {
             event.preventDefault();
-          }
-        }}
-        onOpenAutoFocus={(event) => {
-          // We prevent the initial auto focus because it's a demo rather than a real UI,
-          // so the parent page focus is not stolen.
-          if (initialAutoFocusPrevented.current === false) {
+            if (event.target instanceof HTMLElement && contentRef.current?.contains(event.target)) {
+              setOpen(false);
+            }
+          }}
+          onInteractOutside={(event) => {
+            if (event.target !== triggerRef.current) {
+              event.preventDefault();
+            }
+          }}
+          onOpenAutoFocus={(event: FocusEvent) => {
+            // We prevent the initial auto focus because it's a demo rather than a real UI,
+            // so the parent page focus is not stolen.
             event.preventDefault();
-            initialAutoFocusPrevented.current = true;
-          }
-        }}
-      >
-        <DropdownMenuArrow />
-        <DropdownMenuItem>New Tab</DropdownMenuItem>
-        <DropdownMenuItem>New Window</DropdownMenuItem>
-        <DropdownMenuSeparator />
 
-        <DropdownMenuPrimitive.Sub>
-          <DropdownMenuSubTrigger>
-            Favorites
-            <CaretRightIcon style={{ marginLeft: 'auto', marginRight: -5 }} />
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent>
-            <DropdownMenuItem>
-              <GitHubLogoIcon style={{ marginLeft: -15, marginRight: 10 }} />
-              GitHub
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <StitchesLogoIcon style={{ marginLeft: -15, marginRight: 10 }} />
-              Stitches
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <TwitterLogoIcon style={{ marginLeft: -15, marginRight: 10 }} />
-              Twitter
-            </DropdownMenuItem>
-          </DropdownMenuSubContent>
-        </DropdownMenuPrimitive.Sub>
+            if (initialAutoFocusPrevented.current) {
+              // Restore default behaviour, but prevent the focus scroll
+              // which happens when content wrapper has `position: absolute`
+              setTimeout(() => {
+                contentRef.current.focus({ preventScroll: true });
+              });
+            } else {
+              initialAutoFocusPrevented.current = true;
+            }
+          }}
+        >
+          <DropdownMenuArrow />
+          <DropdownMenuItem>New Tab</DropdownMenuItem>
+          <DropdownMenuItem>New Window</DropdownMenuItem>
+          <DropdownMenuSeparator />
 
-        <DropdownMenuItem>Downloads</DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuCheckboxItem checked={showToolbar} onCheckedChange={setShowToolbar}>
-          <DropdownMenuPrimitive.ItemIndicator>
-            <CheckIcon style={{ marginLeft: -18, marginRight: 0 }} />
-          </DropdownMenuPrimitive.ItemIndicator>
-          Show Toolbar
-        </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem checked={showUrls} onCheckedChange={setShowUrls}>
-          <DropdownMenuPrimitive.ItemIndicator>
-            <CheckIcon style={{ marginLeft: -18, marginRight: 0 }} />
-          </DropdownMenuPrimitive.ItemIndicator>
-          Show Full URLs
-        </DropdownMenuCheckboxItem>
-      </DropdownMenuContent>
+          <DropdownMenuPrimitive.Sub>
+            <DropdownMenuSubTrigger>
+              Favorites
+              <CaretRightIcon style={{ marginLeft: 'auto', marginRight: -5 }} />
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>
+                <GitHubLogoIcon style={{ marginLeft: -15, marginRight: 10 }} />
+                GitHub
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <StitchesLogoIcon style={{ marginLeft: -15, marginRight: 10 }} />
+                Stitches
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <TwitterLogoIcon style={{ marginLeft: -15, marginRight: 10 }} />
+                Twitter
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuPrimitive.Sub>
+
+          <DropdownMenuItem>Downloads</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem checked={showToolbar} onCheckedChange={setShowToolbar}>
+            <DropdownMenuPrimitive.ItemIndicator>
+              <CheckIcon style={{ marginLeft: -18, marginRight: 0 }} />
+            </DropdownMenuPrimitive.ItemIndicator>
+            Show Toolbar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem checked={showUrls} onCheckedChange={setShowUrls}>
+            <DropdownMenuPrimitive.ItemIndicator>
+              <CheckIcon style={{ marginLeft: -18, marginRight: 0 }} />
+            </DropdownMenuPrimitive.ItemIndicator>
+            Show Full URLs
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenuContentWrapper>
     </DropdownMenuPrimitive.Root>
   );
 }

--- a/components/marketing/MainHeroPopover.tsx
+++ b/components/marketing/MainHeroPopover.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
-import { Flex, Text, styled, Grid, TextField, Box } from '@modulz/design-system';
+import { Text, styled, Grid, TextField } from '@modulz/design-system';
 import { DemoButton } from '@components/marketing/DemoButton';
 import { DemoIconButton } from '@components/marketing/DemoIconButton';
 import { Cross2Icon } from '@radix-ui/react-icons';
+
+const PopoverContentWrapper = styled('div', {
+  // The default `position: fixed` is wobbly when scrolling with Mac touchpads,
+  // which is OK when using components for real, but looks awkward in the demos.
+  // `position: absolute` stays put as you scroll.
+  '& [data-radix-popper-content-wrapper]': {
+    position: 'absolute !important',
+  },
+});
 
 const PopoverContent = styled(PopoverPrimitive.Content, {
   position: 'relative',
@@ -36,62 +45,62 @@ export function MainHeroPopover() {
         <DemoButton css={{ mb: 120 }}>Dimensions</DemoButton>
       </PopoverPrimitive.Trigger>
 
-      <PopoverContent
-        ref={contentRef}
-        side="bottom"
-        sideOffset={5}
-        avoidCollisions={false}
-        onInteractOutside={(event) => event.preventDefault()}
-        onEscapeKeyDown={(event) => {
-          event.preventDefault();
-          if (event.target instanceof HTMLElement && contentRef.current?.contains(event.target)) {
-            setOpen(false);
-          }
-        }}
-        onOpenAutoFocus={(event) => {
-          // We prevent the initial auto focus because it's a demo rather than a real UI,
-          // so that the parent page focus is not stolen.
-          if (initialAutoFocusPrevented.current === false) {
+      <PopoverContentWrapper>
+        <PopoverContent
+          ref={contentRef}
+          side="bottom"
+          sideOffset={5}
+          avoidCollisions={false}
+          onInteractOutside={(event) => event.preventDefault()}
+          onEscapeKeyDown={(event) => {
             event.preventDefault();
-            initialAutoFocusPrevented.current = true;
-          } else {
-            // There's a brutal scroll shift bug with iOS Safari that we need to investigate.
-            // Cancelling input focus on open until we figure it out. Not related to the small input font size.
-            if (
-              /^((?!chrome|android).)*safari/i.test(navigator.userAgent) &&
-              navigator.maxTouchPoints > 0
-            ) {
-              event.preventDefault();
+            if (event.target instanceof HTMLElement && contentRef.current?.contains(event.target)) {
+              setOpen(false);
             }
-          }
-        }}
-      >
-        <PopoverArrow />
+          }}
+          onOpenAutoFocus={(event) => {
+            // We prevent the initial auto focus because it's a demo rather than a real UI,
+            // so that the parent page focus is not stolen.
+            event.preventDefault();
 
-        <Text as="h2" size="3" css={{ fontWeight: '500', mb: '$2', lineHeight: 1.2 }}>
-          Dimensions
-        </Text>
-
-        <Grid
-          align="center"
-          css={{ gridTemplateColumns: 'auto 100px', columnGap: '$5', rowGap: '$1' }}
+            if (initialAutoFocusPrevented.current) {
+              // Restore default behaviour, but prevent the focus scroll
+              // which happens when content wrapper has `position: absolute`
+              setTimeout(() => {
+                contentRef.current.focus({ preventScroll: true });
+              });
+            } else {
+              initialAutoFocusPrevented.current = true;
+            }
+          }}
         >
-          <Text size="1">Width</Text>
-          <TextField defaultValue="100%" />
-          <Text size="1">Height</Text>
-          <TextField defaultValue="20vh" />
-          <Text size="1">Margin</Text>
-          <TextField defaultValue="0" />
-          <Text size="1">Padding</Text>
-          <TextField defaultValue="10%" />
-        </Grid>
+          <PopoverArrow />
 
-        <PopoverPrimitive.Close asChild>
-          <DemoIconButton>
-            <Cross2Icon />
-          </DemoIconButton>
-        </PopoverPrimitive.Close>
-      </PopoverContent>
+          <Text as="h2" size="3" css={{ fontWeight: '500', mb: '$2', lineHeight: 1.2 }}>
+            Dimensions
+          </Text>
+
+          <Grid
+            align="center"
+            css={{ gridTemplateColumns: 'auto 100px', columnGap: '$5', rowGap: '$1' }}
+          >
+            <Text size="1">Width</Text>
+            <TextField defaultValue="100%" />
+            <Text size="1">Height</Text>
+            <TextField defaultValue="20vh" />
+            <Text size="1">Margin</Text>
+            <TextField defaultValue="0" />
+            <Text size="1">Padding</Text>
+            <TextField defaultValue="10%" />
+          </Grid>
+
+          <PopoverPrimitive.Close asChild>
+            <DemoIconButton>
+              <Cross2Icon />
+            </DemoIconButton>
+          </PopoverPrimitive.Close>
+        </PopoverContent>
+      </PopoverContentWrapper>
     </PopoverPrimitive.Root>
   );
 }

--- a/components/marketing/MainHeroPopover.tsx
+++ b/components/marketing/MainHeroPopover.tsx
@@ -67,8 +67,9 @@ export function MainHeroPopover() {
               // Restore default behaviour, but prevent the focus scroll
               // which happens when content wrapper has `position: absolute`
               setTimeout(() => {
-                const elementToFocus = contentRef.current.querySelector('input');
-                elementToFocus?.focus({ preventScroll: true });
+                const inputToFocus = contentRef.current.querySelector('input');
+                inputToFocus?.focus({ preventScroll: true });
+                inputToFocus?.select();
               });
             } else {
               initialAutoFocusPrevented.current = true;

--- a/components/marketing/MainHeroPopover.tsx
+++ b/components/marketing/MainHeroPopover.tsx
@@ -67,7 +67,8 @@ export function MainHeroPopover() {
               // Restore default behaviour, but prevent the focus scroll
               // which happens when content wrapper has `position: absolute`
               setTimeout(() => {
-                contentRef.current.focus({ preventScroll: true });
+                const elementToFocus = contentRef.current.querySelector('input');
+                elementToFocus?.focus({ preventScroll: true });
               });
             } else {
               initialAutoFocusPrevented.current = true;


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

Scrolling the homepage with a Mac touchpad would be wobble the dropdown menu and popover, which isn't really an issue when using them for real, but looks awkward on the demos.

Before:
https://user-images.githubusercontent.com/8441036/211537846-dd0cfd7e-8623-4ac6-baba-e4c1feb901f8.mov

After:
https://user-images.githubusercontent.com/8441036/211537893-e949afe5-5d41-4f00-9e09-b4956765a9e6.mov

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
