### PR TITLE
Update `Navigation Menu • With client side routing` example

### DIFF
--- a/data/primitives/docs/components/navigation-menu/1.1.3.mdx
+++ b/data/primitives/docs/components/navigation-menu/1.1.3.mdx
@@ -722,23 +722,19 @@ This will ensure accessibility and consistent keyboard control is maintained. He
 
 ```jsx line=7-16,22,25
 // index.jsx
-import { useRouter } from 'next/router';
+import { usePathname } from 'next/navigation';
 import NextLink from 'next/link';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import './styles.css';
 
 const Link = ({ href, ...props }) => {
-  const router = useRouter();
-  const isActive = router.asPath === href;
+  const pathname = usePathname();
+  const isActive = href === pathname;
 
   return (
-    <NextLink href={href} passHref legacyBehavior>
-      <NavigationMenu.Link
-        className="NavigationMenuLink"
-        active={isActive}
-        {...props}
-      />
-    </NextLink>
+    <NavigationMenu.Link asChild active={isActive}>
+      <NextLink href={href} className="NavigationMenuLink" {...props} />
+    </NavigationMenu.Link>
   );
 };
 


### PR DESCRIPTION
Fix example to reflects Next.js v13 changes.
Next Link requires a `legacyBehavior` attribute when rendering custom `<a>` markup. [cf Next.js doc](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag)

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

## Links
- Fixes #563
- Repo to see change can be found [here](https://github.com/damiencornu/radix-next-navigationmenu-update)
