### PR TITLE
Add antialiasing to Tailwind config

### DIFF
--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -352,6 +352,8 @@ body {
   align-items: flex-start;
   justify-content: center;
   margin-top: 120px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 svg {
@@ -425,6 +427,8 @@ body {
   align-items: flex-start;
   justify-content: center;
   margin-top: 120px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 svg {

--- a/components/HeroCodeBlock.tsx
+++ b/components/HeroCodeBlock.tsx
@@ -508,6 +508,8 @@ body {
   align-items: flex-start;
   justify-content: center;
   margin-top: 120px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }`,
       isBinary: false,
     },


### PR DESCRIPTION
I noticed the fonts were lacking antialiasing in the Tailwind codesandbox, whereas the preview on the Radix website has it. I added this to the Tailwind config. Normally I add the Tailwind `antialiased` class directly to the body tag

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
