### PR TITLE
Add Tailwind CSS demo to Toolbar

### DIFF
--- a/components/demos/Toolbar/css/styles.css
+++ b/components/demos/Toolbar/css/styles.css
@@ -83,4 +83,5 @@ button {
 }
 .ToolbarButton:hover {
   background-color: var(--violet10);
+  color: white;
 }

--- a/components/demos/Toolbar/stitches/index.jsx
+++ b/components/demos/Toolbar/stitches/index.jsx
@@ -106,7 +106,7 @@ const ToolbarButton = styled(
     color: 'white',
     backgroundColor: violet.violet9,
   },
-  { '&:hover': { backgroundColor: violet.violet10 } }
+  { '&:hover': { backgroundColor: violet.violet10, color: 'white' } }
 );
 
 export default ToolbarDemo;

--- a/components/demos/Toolbar/tailwind/index.jsx
+++ b/components/demos/Toolbar/tailwind/index.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import * as Toolbar from '@radix-ui/react-toolbar';
+import {
+  StrikethroughIcon,
+  TextAlignLeftIcon,
+  TextAlignCenterIcon,
+  TextAlignRightIcon,
+  FontBoldIcon,
+  FontItalicIcon,
+} from '@radix-ui/react-icons';
+
+const ToolbarDemo = () => (
+  <Toolbar.Root
+    className="flex p-[10px] w-full min-w-max rounded-md bg-white shadow-[0_2px_10px] shadow-blackA7"
+    aria-label="Formatting options"
+  >
+    <Toolbar.ToggleGroup type="multiple" aria-label="Text formatting">
+      <Toolbar.ToggleItem
+        className="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        value="bold"
+        aria-label="Bold"
+      >
+        <FontBoldIcon />
+      </Toolbar.ToggleItem>
+      <Toolbar.ToggleItem
+        className="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        value="italic"
+        aria-label="Italic"
+      >
+        <FontItalicIcon />
+      </Toolbar.ToggleItem>
+      <Toolbar.ToggleItem
+        className="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        value="strikethrough"
+        aria-label="Strike through"
+      >
+        <StrikethroughIcon />
+      </Toolbar.ToggleItem>
+    </Toolbar.ToggleGroup>
+    <Toolbar.Separator className="w-[1px] bg-mauve6 mx-[10px]" />
+    <Toolbar.ToggleGroup type="single" defaultValue="center" aria-label="Text alignment">
+      <Toolbar.ToggleItem
+        className="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        value="left"
+        aria-label="Left aligned"
+      >
+        <TextAlignLeftIcon />
+      </Toolbar.ToggleItem>
+      <Toolbar.ToggleItem
+        className="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        value="center"
+        aria-label="Center aligned"
+      >
+        <TextAlignCenterIcon />
+      </Toolbar.ToggleItem>
+      <Toolbar.ToggleItem
+        className="flex-shrink-0 flex-grow-0 basis-auto text-mauve11 h-[25px] px-[5px] rounded inline-flex text-[13px] leading-none items-center justify-center bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+        value="right"
+        aria-label="Right aligned"
+      >
+        <TextAlignRightIcon />
+      </Toolbar.ToggleItem>
+    </Toolbar.ToggleGroup>
+    <Toolbar.Separator className="w-[1px] bg-mauve6 mx-[10px]" />
+    <Toolbar.Link
+      className="bg-transparent text-mauve11 inline-flex justify-center items-center hover:bg-transparent hover:cursor-pointer flex-shrink-0 flex-grow-0 basis-auto h-[25px] px-[5px] rounded text-[13px] leading-none bg-white ml-0.5 outline-none hover:bg-violet3 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7 first:ml-0 data-[state=on]:bg-violet5 data-[state=on]:text-violet11"
+      href="#"
+      target="_blank"
+      style={{ marginRight: 10 }}
+    >
+      Edited 2 hours ago
+    </Toolbar.Link>
+    <Toolbar.Button
+      className="px-[10px] text-white bg-violet9 flex-shrink-0 flex-grow-0 basis-auto h-[25px] rounded inline-flex text-[13px] leading-none items-center justify-center outline-none hover:bg-violet10 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7"
+      style={{ marginLeft: 'auto' }}
+    >
+      Share
+    </Toolbar.Button>
+  </Toolbar.Root>
+);
+
+export default ToolbarDemo;

--- a/components/demos/Toolbar/tailwind/index.jsx
+++ b/components/demos/Toolbar/tailwind/index.jsx
@@ -71,7 +71,7 @@ const ToolbarDemo = () => (
       Edited 2 hours ago
     </Toolbar.Link>
     <Toolbar.Button
-      className="px-[10px] text-white bg-violet9 flex-shrink-0 flex-grow-0 basis-auto h-[25px] rounded inline-flex text-[13px] leading-none items-center justify-center outline-none hover:bg-violet10 hover:text-violet11 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7"
+      className="px-[10px] text-white bg-violet9 flex-shrink-0 flex-grow-0 basis-auto h-[25px] rounded inline-flex text-[13px] leading-none items-center justify-center outline-none hover:bg-violet10 focus:relative focus:shadow-[0_0_0_2px] focus:shadow-violet7"
       style={{ marginLeft: 'auto' }}
     >
       Share

--- a/components/demos/Toolbar/tailwind/tailwind.config.js
+++ b/components/demos/Toolbar/tailwind/tailwind.config.js
@@ -1,0 +1,16 @@
+const { blackA, mauve, violet } = require('@radix-ui/colors');
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./App.jsx'],
+  theme: {
+    extend: {
+      colors: {
+        ...blackA,
+        ...mauve,
+        ...violet,
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
Added the Tailwind CSS example to the Toolbar demos. I also resolved an issue with the CSS and Stitches demo where the button had purple text on a dark purple background on hover, making it difficult to read and lacking insufficient color contrast.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
