### PR TITLE
Fix Tailwind Accordion demo

### DIFF
--- a/components/demos/Accordion/tailwind/index.jsx
+++ b/components/demos/Accordion/tailwind/index.jsx
@@ -56,7 +56,7 @@ const AccordionTrigger = React.forwardRef(({ children, className, ...props }, fo
     >
       {children}
       <ChevronDownIcon
-        className="text-violet10 ease-[cubic-bezier(0.87, 0, 0.13, 1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
+        className="text-violet10 ease-[cubic-bezier(0.87,_0,_0.13,_1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
         aria-hidden
       />
     </Accordion.Trigger>


### PR DESCRIPTION
The arbitrary value for the ease class contained spaces which caused it to be broken at build time. I replaced the spaces with underscores which fixes the problem.

https://tailwindcss.com/docs/adding-custom-styles#handling-whitespace

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
