### PR TITLE
Remove useless size prop from dialog trigger

### DIFF
--- a/components/demos/Dialog/css/index.jsx
+++ b/components/demos/Dialog/css/index.jsx
@@ -6,9 +6,7 @@ import './styles.css';
 const DialogDemo = () => (
   <Dialog.Root>
     <Dialog.Trigger asChild>
-      <button className="Button violet" size="large">
-        Edit profile
-      </button>
+      <button className="Button violet">Edit profile</button>
     </Dialog.Trigger>
     <Dialog.Portal>
       <Dialog.Overlay className="DialogOverlay" />

--- a/components/demos/Dialog/stitches/index.jsx
+++ b/components/demos/Dialog/stitches/index.jsx
@@ -7,7 +7,7 @@ import { Cross2Icon } from '@radix-ui/react-icons';
 const DialogDemo = () => (
   <Dialog.Root>
     <Dialog.Trigger asChild>
-      <Button size="large">Edit profile</Button>
+      <Button>Edit profile</Button>
     </Dialog.Trigger>
     <Dialog.Portal>
       <DialogOverlay />

--- a/components/demos/Dialog/tailwind/index.jsx
+++ b/components/demos/Dialog/tailwind/index.jsx
@@ -5,10 +5,7 @@ import { Cross2Icon } from '@radix-ui/react-icons';
 const DialogDemo = () => (
   <Dialog.Root>
     <Dialog.Trigger asChild>
-      <button
-        className="violet text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none"
-        size="large"
-      >
+      <button className="text-violet11 shadow-blackA7 hover:bg-mauve3 inline-flex h-[35px] items-center justify-center rounded-[4px] bg-white px-[15px] font-medium leading-none shadow-[0_2px_10px] focus:shadow-[0_0_0_2px] focus:shadow-black focus:outline-none">
         Edit profile
       </button>
     </Dialog.Trigger>


### PR DESCRIPTION
Remove useless `size` prop from dialog trigger from CSS and Tailwind CSS demos. I'm wondering why use `asChild` in these demos and not use `className` directly on `Dialog.Trigger`, this happens in some other components too.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
