### PR TITLE
Fix pagination navigation to align `Next` page always to the right

### DIFF
--- a/components/DocsPage.tsx
+++ b/components/DocsPage.tsx
@@ -102,7 +102,7 @@ function Pagination({ allRoutes }) {
         >
           {previous && <PaginationLink route={previous} direction="Previous" />}
           {next && (
-            <Box css={{ textAlign: 'right' }}>
+            <Box css={{ textAlign: 'right', flexGrow: 1 }}>
               <PaginationLink route={next} direction="Next" />
             </Box>
           )}


### PR DESCRIPTION
When there's is no `Previous` page (perhaps only the [Introduction page](https://www.radix-ui.com/docs/primitives/overview/introduction)), `Next` page is aligned to the left of the page. Fixing it with `flex-grow` property on the `Next` page element.

**Screenshots for reference:**

**Before**

<img width="1312" alt="Screenshot 2023-02-26 at 6 27 39 PM" src="https://user-images.githubusercontent.com/450559/221411941-e30b6ba2-851c-48f4-99ab-6409141276ed.png">

**After**
<img width="1312" alt="Screenshot 2023-02-26 at 6 27 24 PM" src="https://user-images.githubusercontent.com/450559/221411957-1137d37a-2b30-47ad-b5d5-c34c7cfb509b.png">


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
