### PR TITLE
#638 Fix colors order inconsistency

### DIFF
--- a/data/colors/palette-composition/the-scales.mdx
+++ b/data/colors/palette-composition/the-scales.mdx
@@ -351,19 +351,6 @@ Radix Colors provides 6 gray scales.
 
 Radix Colors provides 2 metal scales.
 
-### Gold
-
-{
-
-<ColorScaleGroup>
-  <ColorScale label="gold" name="gold" />
-  <ColorScale label="goldA" name="goldA" />
-  <ColorScale label="goldDark" name="goldDark" />
-  <ColorScale label="goldDarkA" name="goldDarkA" />
-</ColorScaleGroup>
-
-}
-
 ### Bronze
 
 {
@@ -373,6 +360,19 @@ Radix Colors provides 2 metal scales.
   <ColorScale label="bronzeA" name="bronzeA" />
   <ColorScale label="bronzeDark" name="bronzeDark" />
   <ColorScale label="bronzeDarkA" name="bronzeDarkA" />
+</ColorScaleGroup>
+
+}
+
+### Gold
+
+{
+
+<ColorScaleGroup>
+  <ColorScale label="gold" name="gold" />
+  <ColorScale label="goldA" name="goldA" />
+  <ColorScale label="goldDark" name="goldDark" />
+  <ColorScale label="goldDarkA" name="goldDarkA" />
 </ColorScaleGroup>
 
 }

--- a/pages/colors/index.tsx
+++ b/pages/colors/index.tsx
@@ -657,22 +657,6 @@ export default function ColorsHome() {
               <Box css={{ height: 35 }}></Box>
 
               <Box>
-                <Text css={{ fontSize: '$2' }}>Gold</Text>
-              </Box>
-              <Box css={{ height: 35, backgroundColor: '$gold1' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold2' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold3' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold4' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold5' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold6' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold7' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold8' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold9' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold10' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold11' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$gold12' }}></Box>
-
-              <Box>
                 <Text css={{ fontSize: '$2' }}>Bronze</Text>
               </Box>
               <Box css={{ height: 35, backgroundColor: '$bronze1' }}></Box>
@@ -687,6 +671,22 @@ export default function ColorsHome() {
               <Box css={{ height: 35, backgroundColor: '$bronze10' }}></Box>
               <Box css={{ height: 35, backgroundColor: '$bronze11' }}></Box>
               <Box css={{ height: 35, backgroundColor: '$bronze12' }}></Box>
+
+              <Box>
+                <Text css={{ fontSize: '$2' }}>Gold</Text>
+              </Box>
+              <Box css={{ height: 35, backgroundColor: '$gold1' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold2' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold3' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold4' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold5' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold6' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold7' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold8' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold9' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold10' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold11' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$gold12' }}></Box>
             </Grid>
           </Container>
         </Section>

--- a/pages/colors/index.tsx
+++ b/pages/colors/index.tsx
@@ -517,22 +517,6 @@ export default function ColorsHome() {
               <Box css={{ height: 35, backgroundColor: '$grass12' }}></Box>
 
               <Box>
-                <Text css={{ fontSize: '$2' }}>Brown</Text>
-              </Box>
-              <Box css={{ height: 35, backgroundColor: '$brown1' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown2' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown3' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown4' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown5' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown6' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown7' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown8' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown9' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown10' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown11' }}></Box>
-              <Box css={{ height: 35, backgroundColor: '$brown12' }}></Box>
-
-              <Box>
                 <Text css={{ fontSize: '$2' }}>Orange</Text>
               </Box>
               <Box css={{ height: 35, backgroundColor: '$orange1' }}></Box>
@@ -547,6 +531,22 @@ export default function ColorsHome() {
               <Box css={{ height: 35, backgroundColor: '$orange10' }}></Box>
               <Box css={{ height: 35, backgroundColor: '$orange11' }}></Box>
               <Box css={{ height: 35, backgroundColor: '$orange12' }}></Box>
+
+              <Box>
+                <Text css={{ fontSize: '$2' }}>Brown</Text>
+              </Box>
+              <Box css={{ height: 35, backgroundColor: '$brown1' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown2' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown3' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown4' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown5' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown6' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown7' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown8' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown9' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown10' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown11' }}></Box>
+              <Box css={{ height: 35, backgroundColor: '$brown12' }}></Box>
 
               <Box css={{ height: 35 }}></Box>
               <Box css={{ height: 35 }}></Box>


### PR DESCRIPTION
Closes #638 

## Changes:

- Swap Orange / Brown colors on the home page
- Swap Bronze / Gold colors on the home page
- Swap Bronze / Gold colors on the scales page

## Note

I didn't commit changes to [Lightness test Steps 1–6](https://www.radix-ui.com/docs/colors/tests/balance#steps-16) as I'm not sure if it's intentional or not. 

Feel like the colors order should match other scales on the page, though.