### PR TITLE
Updating broken link on Polymorphic docs page

### DIFF
--- a/data/primitives/components/toolbar/0.1.5.mdx
+++ b/data/primitives/components/toolbar/0.1.5.mdx
@@ -340,7 +340,7 @@ Used to visually separate items in the toolbar.
 
 ### Use with other primitives
 
-All our primitives which expose a `Trigger` part, such as `Dialog`, `AlertDialog`, `Popover`, `DropdownMenu` can be composed within a toolbar by using the [`asChild` prop](/docs/primitives/guides/styling#changing-the-rendered-element).
+All our primitives which expose a `Trigger` part, such as `Dialog`, `AlertDialog`, `Popover`, `DropdownMenu` can be composed within a toolbar by using the [`asChild` prop](/docs/primitives/guides/composition).
 
 Here is an example using our `DropdownMenu` primitive.
 

--- a/data/primitives/components/toolbar/1.0.4.mdx
+++ b/data/primitives/components/toolbar/1.0.4.mdx
@@ -415,7 +415,7 @@ Used to visually separate items in the toolbar.
 
 ### Use with other primitives
 
-All our primitives which expose a `Trigger` part, such as `Dialog`, `AlertDialog`, `Popover`, `DropdownMenu` can be composed within a toolbar by using the [`asChild` prop](/docs/primitives/guides/styling#changing-the-rendered-element).
+All our primitives which expose a `Trigger` part, such as `Dialog`, `AlertDialog`, `Popover`, `DropdownMenu` can be composed within a toolbar by using the [`asChild` prop](/docs/primitives/guides/composition).
 
 Here is an example using our `DropdownMenu` primitive.
 

--- a/data/primitives/components/tooltip/0.1.1.mdx
+++ b/data/primitives/components/tooltip/0.1.1.mdx
@@ -437,7 +437,7 @@ export default () => (
 
 #### Implementation
 
-Use the [`asChild` prop](/docs/primitives/guides/styling#changing-the-rendered-element) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
+Use the [`asChild` prop](/docs/primitives/guides/composition) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
 
 ```jsx line=8-10
 // your-tooltip.jsx

--- a/data/primitives/components/tooltip/0.1.7.mdx
+++ b/data/primitives/components/tooltip/0.1.7.mdx
@@ -476,7 +476,7 @@ export default () => (
 
 #### Implementation
 
-Use the [`asChild` prop](/docs/primitives/guides/styling#changing-the-rendered-element) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
+Use the [`asChild` prop](/docs/primitives/guides/composition) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
 
 ```jsx line=8-10
 // your-tooltip.jsx

--- a/data/primitives/components/tooltip/1.0.3.mdx
+++ b/data/primitives/components/tooltip/1.0.3.mdx
@@ -660,7 +660,7 @@ export default () => (
 
 #### Implementation
 
-Use the [`asChild` prop](/docs/primitives/guides/styling#changing-the-rendered-element) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
+Use the [`asChild` prop](/docs/primitives/guides/composition) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
 
 ```jsx line=8-10
 // your-tooltip.jsx

--- a/data/primitives/components/tooltip/1.0.6.mdx
+++ b/data/primitives/components/tooltip/1.0.6.mdx
@@ -717,7 +717,7 @@ export default () => (
 
 #### Implementation
 
-Use the [`asChild` prop](/docs/primitives/guides/styling#changing-the-rendered-element) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
+Use the [`asChild` prop](/docs/primitives/guides/composition) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
 
 ```jsx line=8-10
 // your-tooltip.jsx

--- a/data/primitives/overview/releases.mdx
+++ b/data/primitives/overview/releases.mdx
@@ -562,7 +562,7 @@ This release focuses on React 18 support and introduces a number breaking change
 
 - All primitives moved to **Beta** and are now versioned <Badge size="1" variant="blue" css={{ fontFamily: '$mono' }}>0.1.0</Badge>
 - [**Breaking**] Replace polymorphic `as` prop with `asChild` boolean prop. Learn more
-  about how to [change the rendered element here](/docs/primitives/guides/styling#changing-the-rendered-element) <PRLink id={835} />
+  about how to [change the rendered element here](/docs/primitives/guides/composition) <PRLink id={835} />
 
 <PackageRelease name="Dialog" version="0.1.0" />
 

--- a/data/primitives/utilities/polymorphic/0.0.14.mdx
+++ b/data/primitives/utilities/polymorphic/0.0.14.mdx
@@ -19,7 +19,7 @@ name: polymorphic
 <Alert>
   This package has been deprecated in favour of the `asChild` prop. Learn more
   about how to [change the rendered element
-  here](/docs/primitives/guides/styling#changing-the-rendered-element).
+  here](/docs/primitives/guides/composition#composition).
 </Alert>
 
 ## Installation

--- a/data/primitives/utilities/polymorphic/0.0.14.mdx
+++ b/data/primitives/utilities/polymorphic/0.0.14.mdx
@@ -19,7 +19,7 @@ name: polymorphic
 <Alert>
   This package has been deprecated in favour of the `asChild` prop. Learn more
   about how to [change the rendered element
-  here](/docs/primitives/guides/composition#composition).
+  here](/docs/primitives/guides/composition).
 </Alert>
 
 ## Installation


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug

It seems there is a broken link on the deprecated Polymorphic docs page in the alert that notifies the user the page has been deprecated. https://www.radix-ui.com/docs/primitives/utilities/polymorphic

This PR updates the link to the Composition page which describes the `asChild` prop in detail https://www.radix-ui.com/docs/primitives/guides/composition#composition

## Before

https://github.com/radix-ui/website/assets/8112138/f9fd7c84-6d2d-4868-b3f1-9843a520f7cd

## After
Apologies committing this through GitHub so don't have a working local environment to record