### PR TITLE
fix: broken link for kbd roving tabindex

### DIFF
--- a/data/primitives/components/context-menu/0.0.1.mdx
+++ b/data/primitives/components/context-menu/0.0.1.mdx
@@ -1049,7 +1049,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.0.17.mdx
+++ b/data/primitives/components/context-menu/0.0.17.mdx
@@ -1059,7 +1059,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.0.19.mdx
+++ b/data/primitives/components/context-menu/0.0.19.mdx
@@ -1071,7 +1071,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.0.22.mdx
+++ b/data/primitives/components/context-menu/0.0.22.mdx
@@ -1255,7 +1255,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.0.23.mdx
+++ b/data/primitives/components/context-menu/0.0.23.mdx
@@ -898,7 +898,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.0.24.mdx
+++ b/data/primitives/components/context-menu/0.0.24.mdx
@@ -899,7 +899,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.0.7.mdx
+++ b/data/primitives/components/context-menu/0.0.7.mdx
@@ -1169,7 +1169,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.0.8.mdx
+++ b/data/primitives/components/context-menu/0.0.8.mdx
@@ -1180,7 +1180,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.1.0.mdx
+++ b/data/primitives/components/context-menu/0.1.0.mdx
@@ -983,7 +983,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/0.1.6.mdx
+++ b/data/primitives/components/context-menu/0.1.6.mdx
@@ -1008,7 +1008,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/1.0.0.mdx
+++ b/data/primitives/components/context-menu/1.0.0.mdx
@@ -1410,7 +1410,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/2.0.1.mdx
+++ b/data/primitives/components/context-menu/2.0.1.mdx
@@ -1439,7 +1439,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/2.1.1.mdx
+++ b/data/primitives/components/context-menu/2.1.1.mdx
@@ -1452,7 +1452,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/context-menu/2.1.4.mdx
+++ b/data/primitives/components/context-menu/2.1.4.mdx
@@ -1543,7 +1543,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.0.1.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.1.mdx
@@ -1139,7 +1139,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.0.17.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.17.mdx
@@ -1137,7 +1137,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.0.19.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.19.mdx
@@ -1126,7 +1126,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.0.22.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.22.mdx
@@ -974,7 +974,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.0.23.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.23.mdx
@@ -962,7 +962,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.0.7.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.7.mdx
@@ -1271,7 +1271,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.0.8.mdx
+++ b/data/primitives/components/dropdown-menu/0.0.8.mdx
@@ -1282,7 +1282,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.1.0.mdx
+++ b/data/primitives/components/dropdown-menu/0.1.0.mdx
@@ -1046,7 +1046,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/0.1.6.mdx
+++ b/data/primitives/components/dropdown-menu/0.1.6.mdx
@@ -1071,7 +1071,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/1.0.0.mdx
+++ b/data/primitives/components/dropdown-menu/1.0.0.mdx
@@ -1493,7 +1493,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/2.0.2.mdx
+++ b/data/primitives/components/dropdown-menu/2.0.2.mdx
@@ -1524,7 +1524,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/dropdown-menu/2.0.5.mdx
+++ b/data/primitives/components/dropdown-menu/2.0.5.mdx
@@ -1615,7 +1615,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/menubar/1.0.0.mdx
+++ b/data/primitives/components/menubar/1.0.0.mdx
@@ -1580,7 +1580,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/components/menubar/1.0.3.mdx
+++ b/data/primitives/components/menubar/1.0.3.mdx
@@ -1671,7 +1671,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 


### PR DESCRIPTION
### Fix
- Replacing broken `kbd roving tabindex` pattern link to new one. 
