### PR TITLE
Fix Copy colors as CSS button

### DIFF
--- a/components/Scale.tsx
+++ b/components/Scale.tsx
@@ -17,6 +17,12 @@ import tinycolor from 'tinycolor2';
 
 type Scale = Record<string, string>;
 
+const toCssCasing = (str: string) =>
+  str
+    .replace(/([a-z])(\d)/, '$1-$2')
+    .replace(/([A-Z])/g, '-$1')
+    .toLowerCase();
+
 const scaleToHSLObject = (name: string, scale: Scale) => {
   const values = Object.entries(scale)
     .map(([key, val]) => `  ${key}: '${val}',`)
@@ -42,6 +48,7 @@ const scaleToHexObject = (name: string, scale: Scale) => {
 
 const scaleToCSS = (name, scale: Scale) => {
   const values = Object.entries(scale)
+    .map(([key, val]) => [toCssCasing(key), val])
     .map(([key, val]) => `  --${key}: ${val};`)
     .join('\n');
   return `.${name} {\n${values}\n}`;
@@ -49,12 +56,14 @@ const scaleToCSS = (name, scale: Scale) => {
 
 const scaleToSASS = (scale: Scale) => {
   return Object.entries(scale)
+    .map(([key, val]) => [toCssCasing(key), val])
     .map(([key, val]) => `$${key}: ${val};`)
     .join('\n');
 };
 
 const scaleToLESS = (scale: Scale) => {
   return Object.entries(scale)
+    .map(([key, val]) => [toCssCasing(key), val])
     .map(([key, val]) => `@${key}: ${val};`)
     .join('\n');
 };


### PR DESCRIPTION
Fix incorrect format when copying colors as CSS / Sass / Less

<img width="810" alt="image" src="https://github.com/radix-ui/website/assets/8441036/5998d765-61c5-44f0-bccb-3214c792de2e">
