### PR TITLE
Fix missing export in Accordion doc anatomy section

### DIFF
--- a/data/primitives/docs/components/accordion/0.0.18.mdx
+++ b/data/primitives/docs/components/accordion/0.0.18.mdx
@@ -35,7 +35,7 @@ Import all parts and piece them together.
 ```jsx
 import * as Accordion from '@radix-ui/react-accordion';
 
-() => (
+export default () => (
   <Accordion.Root>
     <Accordion.Item>
       <Accordion.Header>

--- a/data/primitives/docs/components/accordion/0.1.0.mdx
+++ b/data/primitives/docs/components/accordion/0.1.0.mdx
@@ -35,7 +35,7 @@ Import all parts and piece them together.
 ```jsx
 import * as Accordion from '@radix-ui/react-accordion';
 
-() => (
+export default () => (
   <Accordion.Root>
     <Accordion.Item>
       <Accordion.Header>

--- a/data/primitives/docs/components/accordion/1.0.2.mdx
+++ b/data/primitives/docs/components/accordion/1.0.2.mdx
@@ -35,7 +35,7 @@ Import all parts and piece them together.
 ```jsx
 import * as Accordion from '@radix-ui/react-accordion';
 
-() => (
+export default () => (
   <Accordion.Root>
     <Accordion.Item>
       <Accordion.Header>


### PR DESCRIPTION
Hi, just a minor doc fix, it was missing the `export default` in the Anatomy section of the Accordion doc

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
