### PR TITLE
Add `onSwipeCancel` prop documentation to `<Toast.Root />`

### DIFF
--- a/data/primitives/docs/components/toast/0.1.1.mdx
+++ b/data/primitives/docs/components/toast/0.1.1.mdx
@@ -248,6 +248,17 @@ The toast that automatically closes. It should not be held open to [acquire a us
       ),
     },
     {
+      name: 'onSwipeCancel',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called when a swipe interaction is cancelled. It can be
+          prevented by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
       name: 'forceMount',
       type: 'boolean',
       description:

--- a/data/primitives/docs/components/toast/1.0.0.mdx
+++ b/data/primitives/docs/components/toast/1.0.0.mdx
@@ -256,6 +256,17 @@ The toast that automatically closes. It should not be held open to [acquire a us
       ),
     },
     {
+      name: 'onSwipeCancel',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called when a swipe interaction is cancelled. It can be
+          prevented by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
       name: 'forceMount',
       type: 'boolean',
       description:

--- a/data/primitives/docs/components/toast/1.1.4.mdx
+++ b/data/primitives/docs/components/toast/1.1.4.mdx
@@ -276,6 +276,17 @@ The toast that automatically closes. It should not be held open to [acquire a us
       ),
     },
     {
+      name: 'onSwipeCancel',
+      type: '(event: SwipeEvent) => void',
+      typeSimple: 'function',
+      description: (
+        <span>
+          Event handler called at the end of a swipe interaction. It can be
+          prevented by calling <Code>event.preventDefault</Code>.
+        </span>
+      ),
+    },
+    {
       name: 'forceMount',
       type: 'boolean',
       description:

--- a/data/primitives/docs/components/toast/1.1.5.mdx
+++ b/data/primitives/docs/components/toast/1.1.5.mdx
@@ -281,7 +281,7 @@ The toast that automatically closes. It should not be held open to [acquire a us
       typeSimple: 'function',
       description: (
         <span>
-          Event handler called at the end of a swipe interaction. It can be
+          Event handler called when a swipe interaction is cancelled. It can be
           prevented by calling <Code>event.preventDefault</Code>.
         </span>
       ),


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

## Description

The TS types have `onSwipeCancel` event but the documentation doesn't:

Code:
![CleanShot 2023-06-27 at 16 28 09@2x](https://github.com/radix-ui/website/assets/54036572/60e0c833-ab33-4e78-9973-2cd62df41939)

Docs:
![CleanShot 2023-06-27 at 16 28 36](https://github.com/radix-ui/website/assets/54036572/146eb262-0ea4-4f45-aa19-bca229a6242e)

