### PR TITLE
Fix Step Numbering in Radix Colors Use Cases Table (`components/UseCasesTable.tsx`)

### DIFF
--- a/components/UseCasesTable.tsx
+++ b/components/UseCasesTable.tsx
@@ -66,7 +66,7 @@ export function UseCasesTable() {
               >
                 <td>
                   <Text size="2" as="p">
-                    {i}
+                    {i + 1}
                   </Text>
                 </td>
               </Box>


### PR DESCRIPTION
**This pull request:**
- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

**Description:**
Adjusts the step numbering in the Radix Colors documentation's [use cases](https://www.radix-ui.com/colors/docs/palette-composition/understanding-the-scale) table. Previously, the steps were displayed as `0-11`. This PR changes the numbering to correctly display as `1-12`.