### PR TITLE
Improve examples, link to theme sections

### DIFF
--- a/components/ThemesDocsAssets.tsx
+++ b/components/ThemesDocsAssets.tsx
@@ -12,7 +12,7 @@ import {
   IconButton,
   Inset,
   Link,
-  Separator,
+  ScrollArea,
   Slider,
   Strong,
   Table,
@@ -291,115 +291,112 @@ export function ThemesVariantsExample() {
 export function ThemesScalingExample() {
   const scaleValues = ['90%', '95%', '100%', '105%', '110%'] as const;
   const person = allPeople[6];
-
   return (
-    <Card size="2">
-      <Flex direction="column" my="-4">
-        {scaleValues.map((scaling, i) => (
-          <Flex
-            key={scaling}
-            style={{
-              borderBottom: i + 1 !== scaleValues.length ? '1px dashed var(--gray-7)' : undefined,
-            }}
-            align="center"
-            gap="4"
-          >
-            <Box style={{ minWidth: 70 }}>
-              <Code size="2" color="gray">
-                {scaling}
-              </Code>
-            </Box>
-
-            <Box py="4" asChild>
-              <Theme scaling={scaling} style={{ flex: 1, maxWidth: 240 + 20 * i }}>
-                <Card variant="surface" aria-label={`${scaling} scaled UI example`}>
-                  <Flex gap="3" align="center" aria-hidden>
-                    <Avatar size="3" src={person.image} fallback={person?.name[0].toUpperCase()} />
-                    <Box>
-                      <Text as="div" size="2" weight="bold">
-                        {person.name}
-                      </Text>
-                      <Text as="div" size="2" color="gray">
-                        Approved invoice <Link>#3461</Link>
-                      </Text>
-                    </Box>
-                  </Flex>
-                </Card>
-              </Theme>
-            </Box>
-          </Flex>
-        ))}
-      </Flex>
-    </Card>
+    <PropValueExampleCard>
+      {scaleValues.map((scaling, i) => (
+        <PropValueExampleCardRow
+          value={scaling}
+          bordered={i + 1 !== scaleValues.length}
+          key={scaling}
+        >
+          <Theme scaling={scaling} style={{ flex: 1, maxWidth: 240 + 20 * i }}>
+            <Card variant="surface" aria-label={`${scaling} scaled UI example`}>
+              <Flex gap="3" align="center" aria-hidden>
+                <Avatar size="3" src={person.image} fallback={person?.name[0].toUpperCase()} />
+                <Box>
+                  <Text as="div" size="2" weight="bold">
+                    {person.name}
+                  </Text>
+                  <Text as="div" size="2" color="gray">
+                    Approved invoice <Link>#3461</Link>
+                  </Text>
+                </Box>
+              </Flex>
+            </Card>
+          </Theme>
+        </PropValueExampleCardRow>
+      ))}
+    </PropValueExampleCard>
   );
 }
 
 export function ThemesRadiusExample() {
   const radiusValues = ['none', 'medium', 'full'] as const;
   return (
-    <Card size="2">
-      <Flex direction="column" my="-4">
-        {radiusValues.map((radius, i) => (
-          <Flex
-            key={radius}
-            style={{
-              borderBottom: i + 1 !== radiusValues.length ? '1px dashed var(--gray-7)' : undefined,
-            }}
-            align="center"
-            gap="4"
-          >
-            <Box style={{ minWidth: 70 }}>
-              <Code size="2" color="gray">
-                {radius}
-              </Code>
-            </Box>
-
-            <Box py="4" grow="1" asChild>
-              <Theme radius={radius} style={{ minWidth: 370, maxWidth: 450 }}>
-                <Card variant="surface" size="2">
-                  <Flex gap="3">
-                    <Avatar
-                      size="3"
-                      src={allPeople[4].image}
-                      fallback={allPeople[22]?.name[0].toUpperCase()}
-                    />
-                    <Box grow="1">
-                      <TextArea placeholder="Reply…" />
-                      <Flex gap="3" mt="3" justify="between">
-                        <Flex asChild align="center" gap="2">
-                          <Label>
-                            <Checkbox checked />
-                            <Text size="2">Send to group</Text>
-                          </Label>
-                        </Flex>
-                        <Button>Send message</Button>
-                      </Flex>
-                    </Box>
+    <PropValueExampleCard>
+      {radiusValues.map((radius, i) => (
+        <PropValueExampleCardRow
+          value={radius}
+          bordered={i + 1 !== radiusValues.length}
+          key={radius}
+        >
+          <Theme radius={radius}>
+            <Card variant="surface" size="2" style={{ maxWidth: 480 }}>
+              <Flex gap="3">
+                <Avatar
+                  size="3"
+                  src={allPeople[4].image}
+                  fallback={allPeople[22]?.name[0].toUpperCase()}
+                />
+                <Box grow="1">
+                  <TextArea placeholder="Reply…" />
+                  <Flex gap="6" mt="3" justify="between">
+                    <Flex asChild align="center" gap="2">
+                      <Label>
+                        <Checkbox checked />
+                        <Text size="2">Send to group</Text>
+                      </Label>
+                    </Flex>
+                    <Button>Send message</Button>
                   </Flex>
-                </Card>
-              </Theme>
-            </Box>
-          </Flex>
-        ))}
-      </Flex>
+                </Box>
+              </Flex>
+            </Card>
+          </Theme>
+        </PropValueExampleCardRow>
+      ))}
+    </PropValueExampleCard>
+  );
+}
+
+function PropValueExampleCard({ children }: { children: React.ReactNode }) {
+  return (
+    <Card size="2">
+      <Inset side="all">
+        <ScrollArea>{children}</ScrollArea>
+      </Inset>
     </Card>
   );
 }
 
-export function ThemesBorderRadiusScale() {
+function PropValueExampleCardRow({
+  children,
+  value,
+  bordered,
+}: {
+  children: React.ReactNode;
+  value: string;
+  bordered: boolean;
+}) {
   return (
-    <Flex gap="4" mt="6" mb="5">
-      {[...new Array(6)].map((_, i) => (
-        <Flex direction="column" key={i} grow="1" align="center" gap="3">
-          <Box height="8" width="100%">
-            <DecorativeBox style={{ borderRadius: `var(--radius-${i + 1})` }} />
-          </Box>
+    <Flex
+      style={{
+        borderBottom: bordered ? '1px dashed var(--gray-6)' : undefined,
+      }}
+      align="center"
+      gap="4"
+      px="5"
+      py="4"
+    >
+      <Box style={{ minWidth: 60 }}>
+        <Code size="2" color="gray">
+          {value}
+        </Code>
+      </Box>
 
-          <Text size="1" color="gray">
-            {i + 1}
-          </Text>
-        </Flex>
-      ))}
+      <Box grow="1" style={{ minWidth: 'max-content' }}>
+        {children}
+      </Box>
     </Flex>
   );
 }

--- a/data/themes/docs/components/icon-button.mdx
+++ b/data/themes/docs/components/icon-button.mdx
@@ -105,6 +105,9 @@ Use the `highContrast` prop to add additional contrast.
 ```jsx live=true
 <Flex direction="column" gap="3">
   <Flex gap="3">
+    <IconButton variant="classic">
+      <MagnifyingGlassIcon width="18" height="18" />
+    </IconButton>
     <IconButton variant="solid">
       <MagnifyingGlassIcon width="18" height="18" />
     </IconButton>
@@ -119,6 +122,9 @@ Use the `highContrast` prop to add additional contrast.
     </IconButton>
   </Flex>
   <Flex gap="3">
+    <IconButton variant="classic" highContrast>
+      <MagnifyingGlassIcon width="18" height="18" />
+    </IconButton>
     <IconButton variant="solid" highContrast>
       <MagnifyingGlassIcon width="18" height="18" />
     </IconButton>

--- a/data/themes/docs/theme/overview.mdx
+++ b/data/themes/docs/theme/overview.mdx
@@ -33,31 +33,37 @@ A well tuned set of defaults is provided to get you started, but don’t be afra
       <ThemesLinkCard
         title="Accent color"
         desc="The accent color of primary buttons, links and interactive elements."
+        href="/themes/docs/theme/color#choosing-an-accent-color"
       />
 
       <ThemesLinkCard
         title="Gray color"
         desc="The shade of gray applied to borders, text and non-interactive elements."
+        href="/themes/docs/theme/color#choosing-a-gray-color"
       />
 
       <ThemesLinkCard
         title="Panel background"
         desc="Whether to apply a solid color, or use a translucent effect on panel elements."
+        href="/themes/docs/theme/visual-style#panel-background"
       />
 
       <ThemesLinkCard
         title="Radius"
         desc="The amount of border radius applied to themed elements."
+        href="/themes/docs/theme/visual-style#panel-background"
       />
 
       <ThemesLinkCard
         title="Appearance"
         desc="The color scheme of the theme (typcially referred to as light and dark mode)"
+        href="/themes/docs/theme/dark-mode"
       />
 
       <ThemesLinkCard
         title="Scaling"
         desc="The unform scaling applied to the UI across the entire theme."
+        href="/themes/docs/theme/layout#scaling"
       />
     </Grid>
 


### PR DESCRIPTION
- Link theme overview cards to relevant sections
- Add missing classic variant to some icon button examples
- Improve prop example asset responsive overflow handling