### PR TITLE
fix: typo in docs, href points to incorrect location

### DIFF
--- a/data/themes/docs/theme/overview.mdx
+++ b/data/themes/docs/theme/overview.mdx
@@ -51,7 +51,7 @@ A well tuned set of defaults is provided to get you started, but don’t be afra
       <ThemesLinkCard
         title="Radius"
         desc="The amount of border radius applied to themed elements."
-        href="/themes/docs/theme/visual-style#panel-background"
+        href="/themes/docs/theme/visual-style#radius"
       />
 
       <ThemesLinkCard


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

This can be tested at https://www.radix-ui.com/themes/docs/theme/overview. 

Current behaviour: when clicking on the Radius card directs to https://www.radix-ui.com/themes/docs/theme/visual-style#panel-background.
This should instead be https://www.radix-ui.com/themes/docs/theme/visual-style#radius
