### PR TITLE
Fix the pnpm install command syntax in docs

### DIFF
--- a/data/themes/docs/overview/getting-started.mdx
+++ b/data/themes/docs/overview/getting-started.mdx
@@ -35,7 +35,7 @@ Install the package from your command line.
   <TabsContent value="pnpm">
     <TabsCodeBlockContent
       language="bash"
-      value="pnpm install @radix-ui/themes"
+      value="pnpm add @radix-ui/themes"
     />
   </TabsContent>
 </TabsCodeBlock>


### PR DESCRIPTION
Fix the pnpm install command syntax.

```bash
pnpm install @radix-ui/themes

// fix it 
pnpm add @radix-ui/themes

```

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
