### PR TITLE
Target Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "radix-site",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": "18.x"
+  },
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "dev": "export NODE_OPTIONS=--openssl-legacy-provider && next dev",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && next build",
+    "start": "export NODE_OPTIONS=--openssl-legacy-provider && next start",
     "prettier": "prettier --write .",
     "scraper:setup": "docker run -it --name radix_algolia --env-file=./algolia/.env -e \"CONFIG=$(cat ./algolia/config.development.json | jq -r tostring)\" algolia/docsearch-scraper",
     "scraper:reset": "docker rm radix_algolia && yarn scraper:setup",
@@ -85,7 +88,6 @@
   },
   "devDependencies": {
     "@types/lodash.debounce": "^4.0.6",
-    "@types/node": "^14.14.37",
     "@types/react": "^17.0.3",
     "@types/smoothscroll-polyfill": "^0.3.1",
     "@types/tinycolor2": "^1.4.3",
@@ -102,8 +104,5 @@
       "pre-commit": "pretty-quick --staged"
     }
   },
-  "packageManager": "yarn@1.22.18",
-  "volta": {
-    "node": "16.20.1"
-  }
+  "packageManager": "yarn@1.22.18"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,7 +1905,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
-"@types/node@*", "@types/node@^14.14.37":
+"@types/node@*":
   version "14.14.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
   integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==


### PR DESCRIPTION
We were previously targeting `14.x` which Vercel deprecated support for as of today (Aug 15, 2023) causing all builds to fail.

![CleanShot 2023-08-15 at 13 16 53](https://github.com/radix-ui/website/assets/11708259/9df77646-39ec-4c55-8357-1fd805bf49de)

https://vercel.com/docs/concepts/functions/serverless-functions/runtimes/node-js#node.js-version
