### PR TITLE
Replace `CopyToast` portal usage to fix hydration error

### DIFF
--- a/components/icons/AllIcons.tsx
+++ b/components/icons/AllIcons.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Icons from '@radix-ui/react-icons';
 import { Grid, Tooltip, Heading, Box, IconButton, Flex } from '@radix-ui/themes';
-import { CopyToastVisibility } from './CopyToast';
+import { useCopyToast } from './CopyToast';
 
 import styles from './AllIcons.module.css';
 import { TooltipProvider } from '@radix-ui/react-tooltip';
@@ -45,46 +45,43 @@ type CopyButtonProps = {
 };
 
 const CopyButton = ({ children, label }: CopyButtonProps) => {
+  const { showCopyToast } = useCopyToast();
+
   return (
-    <CopyToastVisibility.Consumer>
-      {({ setIcon, setIsVisible }) => (
-        <Tooltip className="radix-themes-custom-fonts" content={label} side="top" sideOffset={5}>
-          <IconButton
-            highContrast
-            variant="ghost"
-            size="4"
-            onClick={(event: React.MouseEvent) => {
-              const svg = event.currentTarget.querySelector('svg');
-              const code = svg && svg.parentElement ? svg.parentElement.innerHTML : null;
+    <Tooltip className="radix-themes-custom-fonts" content={label} side="top" sideOffset={5}>
+      <IconButton
+        highContrast
+        variant="ghost"
+        size="4"
+        onClick={(event: React.MouseEvent) => {
+          const svg = event.currentTarget.querySelector('svg');
+          const code = svg && svg.parentElement ? svg.parentElement.innerHTML : null;
 
-              // Copy code to clipboard via a hidden textarea element
-              if (code) {
-                // Temporary shim until a proper focus-visible handler is added
-                if (document.activeElement instanceof HTMLButtonElement) {
-                  document.activeElement.blur();
-                }
+          // Copy code to clipboard via a hidden textarea element
+          if (code) {
+            // Temporary shim until a proper focus-visible handler is added
+            if (document.activeElement instanceof HTMLButtonElement) {
+              document.activeElement.blur();
+            }
 
-                const textarea = document.createElement('textarea');
-                textarea.value = code.toString();
-                textarea.setAttribute('readonly', '');
-                textarea.style.position = 'absolute';
-                textarea.style.left = '-9999px';
-                document.body.appendChild(textarea);
-                textarea.select();
-                document.execCommand('copy');
-                document.body.removeChild(textarea);
+            const textarea = document.createElement('textarea');
+            textarea.value = code.toString();
+            textarea.setAttribute('readonly', '');
+            textarea.style.position = 'absolute';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textarea);
 
-                // Show CopyToast and set latest icon
-                setIsVisible();
-                setIcon(code);
-              }
-            }}
-          >
-            {children}
-          </IconButton>
-        </Tooltip>
-      )}
-    </CopyToastVisibility.Consumer>
+            // Show CopyToast and set latest icon
+            showCopyToast(code);
+          }
+        }}
+      >
+        {children}
+      </IconButton>
+    </Tooltip>
   );
 };
 

--- a/components/icons/CopyToast.module.css
+++ b/components/icons/CopyToast.module.css
@@ -1,12 +1,15 @@
-.Toast {
+.ToastViewport {
   position: fixed;
   bottom: 0;
+  left: 0;
+  padding: 0;
+  list-style: none;
+  pointer-events: none;
   width: 100%;
   max-width: calc(100vw - 50px);
-  pointer-events: none;
 }
 
-.ToastInner {
+.Toast {
   pointer-events: auto;
   -webkit-user-select: none;
   user-select: none;
@@ -15,5 +18,34 @@
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-2);
   box-shadow: 0 3px 20px -5px rgba(0, 0, 0, 0.4);
-  transition-property: opacity;
+}
+
+.Toast[data-state='open'] {
+  animation: scaleIn 100ms ease;
+}
+
+.Toast[data-state='closed'] {
+  animation: scaleOut 200ms ease;
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes scaleOut {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.95);
+  }
 }

--- a/components/icons/IconsPanel.tsx
+++ b/components/icons/IconsPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from '@radix-ui/react-icons';
 import { Box, Flex, Heading, Link, Separator, Text } from '@radix-ui/themes';
 import * as React from 'react';
-import { CopyToast, CopyToastVisibility } from './CopyToast';
+import { CopyToastProvider } from './CopyToast';
 import { MainContent } from './MainContent';
 
 import styles from './IconsPanel.module.css';
@@ -26,14 +26,7 @@ export const IconsPanel = () => {
   };
 
   return (
-    <CopyToastVisibility.Provider
-      value={{
-        icon: toastIcon,
-        setIcon: setToastIcon,
-        isVisible: toastIsVisible,
-        setIsVisible: setToastIsVisibleTimeout,
-      }}
-    >
+    <CopyToastProvider>
       <Box
         style={{
           borderRadius: 'var(--radius-4)',
@@ -186,7 +179,6 @@ function MyComponent () {
           </Box>
         </Box>
       </Box>
-      <CopyToast />
-    </CopyToastVisibility.Provider>
+    </CopyToastProvider>
   );
 };

--- a/components/icons/SearchResults.tsx
+++ b/components/icons/SearchResults.tsx
@@ -1,7 +1,7 @@
 import * as Icons from '@radix-ui/react-icons';
 import { Button, Flex, Grid, Text } from '@radix-ui/themes';
 import React from 'react';
-import { CopyToastVisibility } from './CopyToast';
+import { useCopyToast } from './CopyToast';
 
 type SearchResultsProps = {
   value: string;
@@ -30,84 +30,80 @@ const iconNames = Object.keys(Icons).map((key) => {
 });
 
 export const SearchResults = ({ value }: SearchResultsProps) => {
+  const { showCopyToast } = useCopyToast();
   const cleanValue = escapeStringRegexp(value.trim().replace(/\s/g, ' '));
   const matchingNames = iconNames.filter((name) => new RegExp(`\\b${cleanValue}`, 'gi').test(name));
 
   return (
-    <CopyToastVisibility.Consumer>
-      {({ setIcon, setIsVisible }) => (
-        <>
-          {value && matchingNames.length > 0 && (
-            <Grid
-              flow={{ initial: 'row', sm: 'column' }}
-              gapX="6"
-              gapY="5"
-              rows={{
-                sm: `repeat(${Math.max(Math.ceil(matchingNames.length / 2), 3)}, auto)`,
-                md: `repeat(${Math.max(Math.ceil(matchingNames.length / 4), 3)}, auto)`,
-              }}
-              columns={{ initial: '1', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }}
-              py={{ initial: '3', sm: '6' }}
-              px={{ initial: '4', sm: '7' }}
-            >
-              {matchingNames.map((name) => (
-                <Button
-                  key={name}
-                  style={{ justifyContent: 'flex-start' }}
-                  variant="ghost"
-                  highContrast
-                  size="3"
-                  onClick={(event: React.MouseEvent) => {
-                    const svg = event.currentTarget.querySelector('svg');
-                    const code = svg && svg.parentElement ? svg.parentElement.innerHTML : null;
+    <>
+      {value && matchingNames.length > 0 && (
+        <Grid
+          flow={{ initial: 'row', sm: 'column' }}
+          gapX="6"
+          gapY="5"
+          rows={{
+            sm: `repeat(${Math.max(Math.ceil(matchingNames.length / 2), 3)}, auto)`,
+            md: `repeat(${Math.max(Math.ceil(matchingNames.length / 4), 3)}, auto)`,
+          }}
+          columns={{ initial: '1', sm: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }}
+          py={{ initial: '3', sm: '6' }}
+          px={{ initial: '4', sm: '7' }}
+        >
+          {matchingNames.map((name) => (
+            <Button
+              key={name}
+              style={{ justifyContent: 'flex-start' }}
+              variant="ghost"
+              highContrast
+              size="3"
+              onClick={(event: React.MouseEvent) => {
+                const svg = event.currentTarget.querySelector('svg');
+                const code = svg && svg.parentElement ? svg.parentElement.innerHTML : null;
 
-                    // Copy code to clipboard via a hidden textarea element
-                    if (code) {
-                      // Temporary shim until a proper focus-visible handler is added
-                      if (document.activeElement instanceof HTMLButtonElement) {
-                        document.activeElement.blur();
-                      }
+                // Copy code to clipboard via a hidden textarea element
+                if (code) {
+                  // Temporary shim until a proper focus-visible handler is added
+                  if (document.activeElement instanceof HTMLButtonElement) {
+                    document.activeElement.blur();
+                  }
 
-                      const textarea = document.createElement('textarea');
-                      textarea.value = code.toString();
-                      textarea.setAttribute('readonly', '');
-                      textarea.style.position = 'absolute';
-                      textarea.style.left = '-9999px';
-                      document.body.appendChild(textarea);
-                      textarea.select();
-                      document.execCommand('copy');
-                      document.body.removeChild(textarea);
+                  const textarea = document.createElement('textarea');
+                  textarea.value = code.toString();
+                  textarea.setAttribute('readonly', '');
+                  textarea.style.position = 'absolute';
+                  textarea.style.left = '-9999px';
+                  document.body.appendChild(textarea);
+                  textarea.select();
+                  document.execCommand('copy');
+                  document.body.removeChild(textarea);
 
-                      // Show CopyToast and set latest icon
-                      setIsVisible();
-                      setIcon(code);
-                    }
-                  }}
-                >
-                  {React.createElement(Object.values(Icons)[iconNames.indexOf(name)] as any)}
-                  {name}
-                </Button>
-              ))}
-            </Grid>
-          )}
-          {!matchingNames.length && (
-            <Flex
-              align="center"
-              justify="center"
-              py="6"
-              px="6"
-              style={{
-                minHeight: 300,
+                  // Show CopyToast and set latest icon
+                  showCopyToast(code);
+                }
               }}
             >
-              <Text size="2" style={{ textAlign: 'center' }}>
-                No icons for <span style={{ fontWeight: 500 }}>{value}</span>
-              </Text>
-            </Flex>
-          )}
-        </>
+              {React.createElement(Object.values(Icons)[iconNames.indexOf(name)] as any)}
+              {name}
+            </Button>
+          ))}
+        </Grid>
       )}
-    </CopyToastVisibility.Consumer>
+      {!matchingNames.length && (
+        <Flex
+          align="center"
+          justify="center"
+          py="6"
+          px="6"
+          style={{
+            minHeight: 300,
+          }}
+        >
+          <Text size="2" style={{ textAlign: 'center' }}>
+            No icons for <span style={{ fontWeight: 500 }}>{value}</span>
+          </Text>
+        </Flex>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
Next 13 was throwing a hydration error due to this known issue with `Portal`:
https://github.com/radix-ui/primitives/issues/1386

This change updates the offending component to use a `Toast`, this allows us to only render to portal when visible (and also improves a11y).

https://radix-website-git-fix-hydration-error-workos.vercel.app/icons
