### PR TITLE
Fix innacurate Hover Card docs

### DIFF
--- a/data/primitives/docs/components/hover-card/0.0.4.mdx
+++ b/data/primitives/docs/components/hover-card/0.0.4.mdx
@@ -16,7 +16,6 @@ name: hover-card
     'Customize side, alignment, offsets, collision handling.',
     'Optionally render a pointing arrow.',
     'Supports custom open and close delays.',
-    'Opens on hover only.',
     'Ignored by screen readers.',
   ]}
 />
@@ -345,6 +344,19 @@ export default () => (
 
 ## Accessibility
 
+The hover card is intended for sighted users only, the content will be inaccessible to keyboard users.
+
 ### Keyboard Interactions
 
-The hover card is intended for mouse users only so will not respond to keyboard navigation.
+<KeyboardTable
+  data={[
+    {
+      keys: ['Tab'],
+      description: 'Opens/closes the hover card.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Opens the hover card link',
+    },
+  ]}
+/>

--- a/data/primitives/docs/components/hover-card/0.1.5.mdx
+++ b/data/primitives/docs/components/hover-card/0.1.5.mdx
@@ -16,7 +16,6 @@ name: hover-card
     'Customize side, alignment, offsets, collision handling.',
     'Optionally render a pointing arrow.',
     'Supports custom open and close delays.',
-    'Opens on hover only.',
     'Ignored by screen readers.',
   ]}
 />
@@ -366,6 +365,19 @@ export default () => (
 
 ## Accessibility
 
+The hover card is intended for sighted users only, the content will be inaccessible to keyboard users.
+
 ### Keyboard Interactions
 
-The hover card is intended for mouse users only so will not respond to keyboard navigation.
+<KeyboardTable
+  data={[
+    {
+      keys: ['Tab'],
+      description: 'Opens/closes the hover card.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Opens the hover card link',
+    },
+  ]}
+/>

--- a/data/primitives/docs/components/hover-card/1.0.3.mdx
+++ b/data/primitives/docs/components/hover-card/1.0.3.mdx
@@ -16,7 +16,6 @@ name: hover-card
     'Customize side, alignment, offsets, collision handling.',
     'Optionally render a pointing arrow.',
     'Supports custom open and close delays.',
-    'Opens on hover only.',
     'Ignored by screen readers.',
   ]}
 />
@@ -495,6 +494,19 @@ export default () => (
 
 ## Accessibility
 
+The hover card is intended for sighted users only, the content will be inaccessible to keyboard users.
+
 ### Keyboard Interactions
 
-The hover card is intended for mouse users only so will not respond to keyboard navigation.
+<KeyboardTable
+  data={[
+    {
+      keys: ['Tab'],
+      description: 'Opens/closes the hover card.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Opens the hover card link',
+    },
+  ]}
+/>

--- a/data/primitives/docs/components/hover-card/1.0.6.mdx
+++ b/data/primitives/docs/components/hover-card/1.0.6.mdx
@@ -22,7 +22,6 @@ name: hover-card
     'Customize side, alignment, offsets, collision handling.',
     'Optionally render a pointing arrow.',
     'Supports custom open and close delays.',
-    'Opens on hover only.',
     'Ignored by screen readers.',
   ]}
 />
@@ -554,4 +553,15 @@ export default () => (
 
 ### Keyboard Interactions
 
-The hover card is intended for mouse users only so will not respond to keyboard navigation.
+<KeyboardTable
+  data={[
+    {
+      keys: ['Tab'],
+      description: 'Opens/closes the hover card.',
+    },
+    {
+      keys: ['Enter'],
+      description: 'Opens the hover card link',
+    },
+  ]}
+/>

--- a/data/primitives/docs/components/hover-card/1.0.6.mdx
+++ b/data/primitives/docs/components/hover-card/1.0.6.mdx
@@ -551,6 +551,8 @@ export default () => (
 
 ## Accessibility
 
+The hover card is intended for sighted users only, the content will be inaccessible to keyboard users.
+
 ### Keyboard Interactions
 
 <KeyboardTable


### PR DESCRIPTION
This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [X] Updates documentation or example code
- [ ] Other

The current docs state that Hover Card only works on hover. This is no longer the case, as focus also triggers it.