### PR TITLE
Fix Icons search results copying the icon name

### DIFF
--- a/components/icons/SearchResults.tsx
+++ b/components/icons/SearchResults.tsx
@@ -58,7 +58,7 @@ export const SearchResults = ({ value }: SearchResultsProps) => {
               size="3"
               onClick={(event: React.MouseEvent) => {
                 const svg = event.currentTarget.querySelector('svg');
-                const code = svg && svg.parentElement ? svg.parentElement.innerHTML : null;
+                const code = svg ? svg.outerHTML : null;
 
                 // Copy code to clipboard via a hidden textarea element
                 if (code) {


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

Clicking an icon on the main page copies its svg content. However doing the same on the search results page copies the icon name as well.

Example:
Clicking on an icon on the main page:
```
<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
    <path d="M9.875 7.5C9.875 8.81168 8.81168 9.875 7.5 9.875C6.18832 9.875 5.125 8.81168 5.125 7.5C5.125 6.18832 6.18832 5.125 7.5 5.125C8.81168 5.125 9.875 6.18832 9.875 7.5Z" fill="currentColor"></path>
</svg>
```

Clicking on an icon on the search results page:
```
<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
    <path d="M9.875 7.5C9.875 8.81168 8.81168 9.875 7.5 9.875C6.18832 9.875 5.125 8.81168 5.125 7.5C5.125 6.18832 6.18832 5.125 7.5 5.125C8.81168 5.125 9.875 6.18832 9.875 7.5Z" fill="currentColor"></path>
</svg>Dot Filled
```