### PR TITLE
fix: typo in URL of git repo, leads to 404 route

### DIFF
--- a/components/DocsNav.tsx
+++ b/components/DocsNav.tsx
@@ -36,7 +36,7 @@ export const DocsNav = ({ routes }: DocsNavProps) => {
           {section.pages.map((page) => (
             <DocsNavItem
               key={page.slug}
-              href={`/${page.slug}`}
+              href={page.slug}
               active={currentPageSlug === page.slug}
             >
               <Flex gap="2" align="center">
@@ -73,26 +73,18 @@ interface DocsNavItemProps {
 
 const DocsNavItem = ({ active, disabled, href, ...props }: DocsNavItemProps) => {
   const className = classNames(styles.DocsNavItem, active && styles.active);
-  const isExternal = href.startsWith('http') || href.startsWith('/http');
+  const isExternal = href.startsWith('http');
 
   if (disabled) {
     return <span className={className} {...props} />;
   }
 
   if (isExternal) {
-    return (
-      <a
-        className={className}
-        href={href?.replace(/^\/+/, '')}
-        target="_blank"
-        rel="noopener"
-        {...props}
-      />
-    );
+    return <a className={className} href={href} target="_blank" rel="noopener" {...props} />;
   }
 
   return (
-    <NextLink passHref legacyBehavior href={href}>
+    <NextLink passHref legacyBehavior href={`/${href}`}>
       <a className={className} {...props} />
     </NextLink>
   );

--- a/components/DocsNav.tsx
+++ b/components/DocsNav.tsx
@@ -73,14 +73,22 @@ interface DocsNavItemProps {
 
 const DocsNavItem = ({ active, disabled, href, ...props }: DocsNavItemProps) => {
   const className = classNames(styles.DocsNavItem, active && styles.active);
-  const isExternal = href.startsWith('http');
+  const isExternal = href.startsWith('http') || href.startsWith('/http');
 
   if (disabled) {
     return <span className={className} {...props} />;
   }
 
   if (isExternal) {
-    return <a className={className} href={href} target="_blank" rel="noopener" {...props} />;
+    return (
+      <a
+        className={className}
+        href={href?.replace(/^\/+/, '')}
+        target="_blank"
+        rel="noopener"
+        {...props}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

### What this PR does:
This PR fixes the typo in github URL of themes, colors, primitives and others. The error happens in the mobile menu when accessing the github repos.

### Test Environment:
You can test the change in the URL below.
[Test URL](https://radix-ui-fix-url.vercel.app/)