### PR TITLE
fix: Delete duplicated onValueChange prop in Accordion component

### DIFF
--- a/data/primitives/docs/components/accordion/1.1.2.mdx
+++ b/data/primitives/docs/components/accordion/1.1.2.mdx
@@ -154,18 +154,6 @@ Contains all the parts of an accordion.
       ),
     },
     {
-      name: 'onValueChange',
-      required: false,
-      type: '(value: string[]) => void',
-      typeSimple: 'function',
-      description: (
-        <span>
-          Event handler called when the expanded state of an item changes and{' '}
-          <Code>type</Code> is <Code>"multiple"</Code>.
-        </span>
-      ),
-    },
-    {
       name: 'collapsible',
       required: false,
       default: 'false',


### PR DESCRIPTION
## Problem

In the documentation of the Accordion component, the `onValueChange` root prop is cited twice.

https://www.radix-ui.com/primitives/docs/components/accordion#root

## Solution

In this PR, I remove the unnecessary second mention.

## Future Improvement

In another PR, order the props in alphabetical order. This will:

- Avoid other/future duplication
- Ease the search of a property for a component

### This pull request is about:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
