### PR TITLE
Update MagicCurtain animation

### DIFF
--- a/components/MagicCurtain.module.css
+++ b/components/MagicCurtain.module.css
@@ -48,6 +48,11 @@
     animation-duration: var(--animation-duration);
     animation-timing-function: ease-in-out;
   }
+
+  .MagicCurtainItem[data-visibility='visible']
+    ~ .MagicCurtainItem[data-visibility='animating-out'] {
+    animation-name: magic-curtain-clip-reverse;
+  }
 }
 
 /* Firefox has performance issues at high pixel count */
@@ -85,6 +90,15 @@
   }
 }
 
+@keyframes magic-curtain-clip-reverse {
+  0% {
+    clip-path: polygon(-20% 0, 100% 0, 100% 100%, 0 100%);
+  }
+  100% {
+    clip-path: polygon(120% 0, 100% 0, 100% 100%, 100% 100%);
+  }
+}
+
 @media (min-width: 1000px) {
   @keyframes magic-curtain-clip {
     0% {
@@ -92,6 +106,15 @@
     }
     100% {
       clip-path: polygon(0 0, -5% 0, 0 100%, 0 100%);
+    }
+  }
+
+  @keyframes magic-curtain-clip-reverse {
+    0% {
+      clip-path: polygon(-5% 0, 100% 0, 100% 100%, 0 100%);
+    }
+    100% {
+      clip-path: polygon(105% 0, 100% 0, 100% 100%, 100% 100%);
     }
   }
 }

--- a/components/MagicCurtain.tsx
+++ b/components/MagicCurtain.tsx
@@ -148,6 +148,7 @@ const MagicCurtainControls = ({ images }: MagicCurtainControlsProps) => {
         const isMagicCurtainAnimation = [
           styles['magic-curtain-fade'],
           styles['magic-curtain-clip'],
+          styles['magic-curtain-clip-reverse'],
         ].includes(event.animationName);
 
         if (event.target instanceof HTMLElement && isMagicCurtainAnimation) {


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [x] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other


To improve the animation of the awesome MagicCurtain, I made some changes. 
I've kept the changes to a minimum, but please let me know if there's anything else.

Previously, the animation moved uniformly from right to left. I've updated it so that when you select an item to the left of the currently selected one, it animates from left to right. 

This update provides a more natural and captivating user experience.

[Preview  URL](https://radix-website-f9jclhqto-workos.vercel.app/)

| Before

![before](https://github.com/radix-ui/website/assets/58458130/905323b3-a8bf-4e7e-80a3-f27ad8bc72b3)

| After

![after](https://github.com/radix-ui/website/assets/58458130/1655f7e8-80d7-4445-9a5f-c54763ba03ab)

A big thanks to all the members of Radix!
