### PR TITLE
docs(accordion): fix anatomy section

### DIFF
--- a/data/primitives/docs/components/accordion/1.1.2.mdx
+++ b/data/primitives/docs/components/accordion/1.1.2.mdx
@@ -43,7 +43,7 @@ Import all parts and piece them together.
 ```jsx
 import * as Accordion from '@radix-ui/react-accordion';
 
-() => (
+export default () => (
   <Accordion.Root>
     <Accordion.Item>
       <Accordion.Header>


### PR DESCRIPTION
This small PR fixes the documentation for Anatomy section of [Accordion](https://www.radix-ui.com/primitives/docs/components/accordion#anatomy) component so that it is consistent with other components.

```diff
import * as Accordion from '@radix-ui/react-accordion';

- () => (
+ export default () => (
  <Accordion.Root>
    <Accordion.Item>
      <Accordion.Header>
        <Accordion.Trigger />
      </Accordion.Header>
      <Accordion.Content />
    </Accordion.Item>
  </Accordion.Root>
);
```



This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
