### PR TITLE
Correct URLs mismatch in the link cards

### DIFF
--- a/data/themes/docs/overview/getting-started.mdx
+++ b/data/themes/docs/overview/getting-started.mdx
@@ -133,13 +133,13 @@ Get the most out of Radix Themes by exploring more concepts and features.
       <ThemesLinkCard
         title="Visual style"
         desc="Learn how variants, radii and shadows influence your apps visual style."
-        href="/themes/docs/theme/dark-mode"
+        href="/themes/docs/theme/visual-style"
       />
 
       <ThemesLinkCard
         title="Color"
         desc="Understand the color system and its application in your theme."
-        href="/themes/docs/theme/dark-mode"
+        href="/themes/docs/theme/color"
       />
 
       <ThemesLinkCard
@@ -157,7 +157,7 @@ Get the most out of Radix Themes by exploring more concepts and features.
       <ThemesLinkCard
         title="Layout"
         desc="Leverage the built-in responsive design utilities and prop syntax."
-        href="/themes/docs/theme/breakpoints"
+        href="/themes/docs/theme/layout"
       />
     </Grid>
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->


Updated URLs on the link cards to match the intended destination.
For example, the `Visual style` link card should take user to `theme/visual-style` instead of `theme/dark-mode` 


<img width="887" alt="Screenshot 2023-10-08 at 9 12 19 PM" src="https://github.com/radix-ui/website/assets/39371503/36af7e9a-7be6-450c-8403-f2b948e9a0cf">



- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
