### PR TITLE
docs(tooltip) Remove "Displaying a tooltip from a disabled button" section

### DIFF
--- a/data/primitives/docs/components/tooltip/1.0.6.mdx
+++ b/data/primitives/docs/components/tooltip/1.0.6.mdx
@@ -526,30 +526,6 @@ export default () => (
 );
 ```
 
-### Displaying a tooltip from a disabled button
-
-Since disabled buttons don't fire events, you need to:
-
-- Render the `Trigger` as `span`.
-- Ensure the `button` has no `pointerEvents`.
-
-```jsx line=5-11
-import * as Tooltip from '@radix-ui/react-tooltip';
-
-export default () => (
-  <Tooltip.Root>
-    <Tooltip.Trigger __asChild__>
-      <span tabIndex={0}>
-        <button disabled style={{ __pointerEvents__: 'none' }}>
-          …
-        </button>
-      </span>
-    </Tooltip.Trigger>
-    <Tooltip.Content>…</Tooltip.Content>
-  </Tooltip.Root>
-);
-```
-
 ### Constrain the content size
 
 You may want to constrain the width of the content so that it matches the trigger width. You may also want to constrain its height to not exceed the viewport.


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
 
The documentation for `Tooltip` has a section [Displaying a tooltip from a disabled button](https://www.radix-ui.com/docs/primitives/components/tooltip#displaying-a-tooltip-from-a-disabled-button) which suggests that some extra actions should be taken to display tooltips for disabled buttons.

As we can see in this [sandbox](https://codesandbox.io/s/pedantic-curie-eojbiv?file=/App.js) these steps are not required and tooltips are shown for disabled buttons by default.

The issue is a follow-up to the [discussion in discord](https://discord.com/channels/752614004387610674/803656530259738674/1067059191140843540) @benoitgrelard found the PR https://github.com/radix-ui/primitives/pull/1358 that caused the change in behaviour

This PR updates the documentation to reflect those changes.

### Original issue
[[Tooltip] tooltips are shown for disabled buttons but documentation says it shouldn't happen
](https://github.com/radix-ui/primitives/issues/1914)

### Change preview 
https://website-one-delta-46.vercel.app/primitives/docs/components/tooltip

Closes #1914