### PR TITLE
docs(react-slot): mention <Slottable /> in docs add an example for its usage

### DIFF
--- a/data/primitives/docs/utilities/slot/1.0.2.mdx
+++ b/data/primitives/docs/utilities/slot/1.0.2.mdx
@@ -36,6 +36,8 @@ export default () => (
 
 Use to create your own `asChild` API.
 
+When your component has a single children element:
+
 ```jsx line=9
 // your-button.jsx
 import React from 'react';
@@ -44,6 +46,25 @@ import { Slot } from '@radix-ui/react-slot';
 function Button({ asChild, ...props }) {
   const Comp = asChild ? Slot : 'button';
   return <Comp {...props} />;
+}
+```
+
+Use <Slottable /> when your component has multiple childrens to pass the props to the correct element:
+
+```jsx
+// your-button.jsx
+import React from 'react';
+import { Slot, Slottable } from '@radix-ui/react-slot';
+
+function Button({ asChild, leftElement, rightElement, ...props }) {
+  const Comp = asChild ? Slot : 'button';
+  return (
+    <Comp {...props}>
+      {leftElement}
+      <Slottable>{children}</Slottable>
+      {rightElement}
+    </Comp>
+  );
 }
 ```
 
@@ -58,6 +79,8 @@ export default () => (
   </Button>
 );
 ```
+
+
 
 ### Event handlers
 


### PR DESCRIPTION
This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

Update documentation for react-slot component, mention Slottable component and add an example for its usage.