### PR TITLE
Add `Basic Usage` section for Visual Style page

### DIFF
--- a/data/themes/docs/theme/visual-style.mdx
+++ b/data/themes/docs/theme/visual-style.mdx
@@ -17,6 +17,16 @@ Passing the `translucent` value creates a subtle overlay effect on these element
   <ThemesPanelTranslucentExample />
 </Box>
 
+## Basic usage
+
+By default, the root `Theme` panel background is `solid`. To set a different panel background pass it via the `panelBackground` prop. This will force the theme to use the specified setting.
+
+```jsx line=1
+<Theme __panelBackground__="translucent">
+  <MyApp />
+</Theme>
+```
+
 While `solid` is useful when you'd prefer to present information unobstructed.
 
 <Box my="5">

--- a/data/themes/docs/theme/visual-style.mdx
+++ b/data/themes/docs/theme/visual-style.mdx
@@ -17,7 +17,13 @@ Passing the `translucent` value creates a subtle overlay effect on these element
   <ThemesPanelTranslucentExample />
 </Box>
 
-## Basic usage
+While `solid` is useful when you'd prefer to present information unobstructed.
+
+<Box my="5">
+  <ThemesPanelSolidExample />
+</Box>
+
+### Basic usage
 
 By default, the root `Theme` panel background is `solid`. To set a different panel background pass it via the `panelBackground` prop. This will force the theme to use the specified setting.
 
@@ -26,12 +32,6 @@ By default, the root `Theme` panel background is `solid`. To set a different pan
   <MyApp />
 </Theme>
 ```
-
-While `solid` is useful when you'd prefer to present information unobstructed.
-
-<Box my="5">
-  <ThemesPanelSolidExample />
-</Box>
 
 ## Radius
 


### PR DESCRIPTION
This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

Adds `Basic Usage` section to visual style page in docs to align with other pages.

Closes #716 
