### PR TITLE
Fix typo in Radix Themes Dialog documentation

### DIFF
--- a/data/themes/docs/components/dialog.mdx
+++ b/data/themes/docs/components/dialog.mdx
@@ -141,11 +141,11 @@ Use the [Inset](/themes/docs/components/inset) component to align content flush 
     </Inset>
 
     <Flex gap="3" justify="end">
-      <DialogClose>
+      <Dialog.Close>
         <Button variant="soft" color="gray">
           Close
         </Button>
-      </DialogClose>
+      </Dialog.Close>
     </Flex>
   </Dialog.Content>
 </Dialog.Root>


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

This PR fixes a typo in the Dialog docs where it said `<DialogClose>` rather than `<Dialog.Close>`

https://www.radix-ui.com/themes/docs/components/dialog

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
