### PR TITLE
Fix missing `export default` in accordion anatomy 

### DIFF
--- a/data/primitives/docs/components/accordion/1.1.2.mdx
+++ b/data/primitives/docs/components/accordion/1.1.2.mdx
@@ -43,7 +43,7 @@ Import all parts and piece them together.
 ```jsx
 import * as Accordion from '@radix-ui/react-accordion';
 
-() => (
+export default () => (
   <Accordion.Root>
     <Accordion.Item>
       <Accordion.Header>


### PR DESCRIPTION
Updates accordion documentation anatomy example code.