### PR TITLE
Fix a typo in ContextMenu example code

### DIFF
--- a/components/demos/ContextMenu/css/index.jsx
+++ b/components/demos/ContextMenu/css/index.jsx
@@ -17,7 +17,7 @@ const ContextMenuDemo = () => {
             Back <div className="RightSlot">⌘+[</div>
           </ContextMenu.Item>
           <ContextMenu.Item className="ContextMenuItem" disabled>
-            Foward <div className="RightSlot">⌘+]</div>
+            Forward <div className="RightSlot">⌘+]</div>
           </ContextMenu.Item>
           <ContextMenu.Item className="ContextMenuItem">
             Reload <div className="RightSlot">⌘+R</div>

--- a/components/demos/ContextMenu/stitches/index.jsx
+++ b/components/demos/ContextMenu/stitches/index.jsx
@@ -18,7 +18,7 @@ const ContextMenuDemo = () => {
             Back <RightSlot>⌘+[</RightSlot>
           </ContextMenuItem>
           <ContextMenuItem disabled>
-            Foward <RightSlot>⌘+]</RightSlot>
+            Forward <RightSlot>⌘+]</RightSlot>
           </ContextMenuItem>
           <ContextMenuItem>
             Reload <RightSlot>⌘+R</RightSlot>

--- a/components/demos/ContextMenu/tailwind/index.jsx
+++ b/components/demos/ContextMenu/tailwind/index.jsx
@@ -28,7 +28,7 @@ const ContextMenuDemo = () => {
             className="group text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] px-[5px] relative pl-[25px] select-none outline-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
             disabled
           >
-            Foward{' '}
+            Forward{' '}
             <div className="ml-auto pl-5 text-mauve11 group-data-[highlighted]:text-white group-data-[disabled]:text-mauve8">
               ⌘+]
             </div>


### PR DESCRIPTION
`Foward` to `Forward`

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

Preview link: https://radix-website-git-fork-andreasmcdermott-main-workos.vercel.app/primitives/docs/components/context-menu
