### PR TITLE
feat(icon): update copy icon on website

### DIFF
--- a/components/icons/AllIcons.tsx
+++ b/components/icons/AllIcons.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import * as Icons from '@radix-ui/react-icons';
-import { Grid, Tooltip, Heading, Box, IconButton, Flex } from '@radix-ui/themes';
+import {
+  Grid,
+  Tooltip,
+  Heading,
+  Box,
+  IconButton,
+  Flex,
+  DropdownMenu,
+  Text,
+} from '@radix-ui/themes';
 import { useCopyToast } from './CopyToast';
 
 import styles from './AllIcons.module.css';
@@ -47,41 +56,54 @@ type CopyButtonProps = {
 const CopyButton = ({ children, label }: CopyButtonProps) => {
   const { showCopyToast } = useCopyToast();
 
+  const handleCopyCode = React.useCallback(
+    (code) => {
+      navigator.clipboard.writeText(code);
+      showCopyToast(code);
+    },
+    [label, showCopyToast]
+  );
+
+  const handleCopyLabel = React.useCallback(() => {
+    const formattedLabel = label
+      .split(' ')
+      .map((word) => word[0].toUpperCase() + word.slice(1))
+      .join('')
+      .concat('Icon');
+
+    navigator.clipboard.writeText(formattedLabel);
+    showCopyToast(formattedLabel);
+  }, [label, showCopyToast]);
+
   return (
-    <Tooltip className="radix-themes-custom-fonts" content={label} side="top" sideOffset={5}>
-      <IconButton
-        highContrast
-        variant="ghost"
-        size="4"
-        onClick={(event: React.MouseEvent) => {
-          const svg = event.currentTarget.querySelector('svg');
-          const code = svg ? svg.outerHTML : null;
+    <DropdownMenu.Root>
+      <Tooltip className="radix-themes-custom-fonts" content={label} side="top" sideOffset={5}>
+        <DropdownMenu.Trigger>
+          <IconButton highContrast variant="ghost" size="4">
+            {children}
+          </IconButton>
+        </DropdownMenu.Trigger>
+      </Tooltip>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item
+          onClick={(event: React.MouseEvent) => {
+            const svg = event.currentTarget.querySelector('svg');
+            const code = svg ? svg.outerHTML : null;
 
-          // Copy code to clipboard via a hidden textarea element
-          if (code) {
-            // Temporary shim until a proper focus-visible handler is added
-            if (document.activeElement instanceof HTMLButtonElement) {
-              document.activeElement.blur();
-            }
-
-            const textarea = document.createElement('textarea');
-            textarea.value = code.toString();
-            textarea.setAttribute('readonly', '');
-            textarea.style.position = 'absolute';
-            textarea.style.left = '-9999px';
-            document.body.appendChild(textarea);
-            textarea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textarea);
-
-            // Show CopyToast and set latest icon
-            showCopyToast(code);
-          }
-        }}
-      >
-        {children}
-      </IconButton>
-    </Tooltip>
+            code ? handleCopyCode(code) : null;
+          }}
+        >
+          Copy SVG <Text hidden>{children}</Text>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onClick={() => {
+            handleCopyLabel();
+          }}
+        >
+          Copy label
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
   );
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [x] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

<hr>

Hello 👋

I've added the ability to copy the SVG code or label of an icon to a drop-down list. I think it's a good thing, especially when integrating the NPM package, to be able to directly copy the name of the icon to integrate it. A request has already been made for this on the wrong project, I think.  [radix-ui/icons#160](https://github.com/radix-ui/icons/issues/160)

Here is the preview link : [https://radix-ui-swqz-f960ss9vp-vimeux.vercel.app/icons](https://radix-ui-swqz-f960ss9vp-vimeux.vercel.app/icons)
