### PR TITLE
Fix: code block line highlighting (#732)

### DIFF
--- a/components/Pre.module.css
+++ b/components/Pre.module.css
@@ -90,7 +90,8 @@
 }
 
 .Pre > code {
-  display: block;
+  display: inline-block;
+  min-width: 100%;
 }
 
 .Pre :where(:global(.token.punctuation), :global(.token.plain-text)) {


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

---
This pull request addresses the issue where the highlighted line does not expand to fill the entire width when the code block overflows (#732).

### Issue 

![Screenshot_20231230_113037](https://github.com/radix-ui/website/assets/45687883/68544dfe-7996-4c46-86bb-514088037460)

### Fix

![Screenshot_20231230_113502](https://github.com/radix-ui/website/assets/45687883/ab1937e1-f691-477a-9fef-88eca209a599)

[**Live URL**](https://radix-ui-website.vercel.app/) - https://radix-ui-website.vercel.app/