### PR TITLE
Fix broken accessibility document link

### DIFF
--- a/data/primitives/docs/components/accordion/0.0.1.mdx
+++ b/data/primitives/docs/components/accordion/0.0.1.mdx
@@ -428,7 +428,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/accordion/0.0.15.mdx
+++ b/data/primitives/docs/components/accordion/0.0.15.mdx
@@ -686,7 +686,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/accordion/0.0.18.mdx
+++ b/data/primitives/docs/components/accordion/0.0.18.mdx
@@ -364,7 +364,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/accordion/0.0.5.mdx
+++ b/data/primitives/docs/components/accordion/0.0.5.mdx
@@ -488,7 +488,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/accordion/0.0.6.mdx
+++ b/data/primitives/docs/components/accordion/0.0.6.mdx
@@ -655,7 +655,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/accordion/0.1.0.mdx
+++ b/data/primitives/docs/components/accordion/0.1.0.mdx
@@ -399,7 +399,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/accordion/1.0.2.mdx
+++ b/data/primitives/docs/components/accordion/1.0.2.mdx
@@ -499,7 +499,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/accordion/1.1.2.mdx
+++ b/data/primitives/docs/components/accordion/1.1.2.mdx
@@ -560,7 +560,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion).
+Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.1.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.1.mdx
@@ -1049,7 +1049,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.17.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.17.mdx
@@ -1059,7 +1059,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.19.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.19.mdx
@@ -1071,7 +1071,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.22.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.22.mdx
@@ -1255,7 +1255,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.23.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.23.mdx
@@ -898,7 +898,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.24.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.24.mdx
@@ -899,7 +899,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.7.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.7.mdx
@@ -1169,7 +1169,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.0.8.mdx
+++ b/data/primitives/docs/components/context-menu/0.0.8.mdx
@@ -1180,7 +1180,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.1.0.mdx
+++ b/data/primitives/docs/components/context-menu/0.1.0.mdx
@@ -983,7 +983,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/0.1.6.mdx
+++ b/data/primitives/docs/components/context-menu/0.1.6.mdx
@@ -1008,7 +1008,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/1.0.0.mdx
+++ b/data/primitives/docs/components/context-menu/1.0.0.mdx
@@ -1410,7 +1410,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/2.0.1.mdx
+++ b/data/primitives/docs/components/context-menu/2.0.1.mdx
@@ -1439,7 +1439,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/2.1.1.mdx
+++ b/data/primitives/docs/components/context-menu/2.1.1.mdx
@@ -1452,7 +1452,7 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/context-menu/2.1.4.mdx
+++ b/data/primitives/docs/components/context-menu/2.1.4.mdx
@@ -1543,6 +1543,8 @@ export default () => (
 
 ## Accessibility
 
+Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
+
 ### Keyboard Interactions
 
 <KeyboardTable

--- a/data/primitives/docs/components/context-menu/2.1.4.mdx
+++ b/data/primitives/docs/components/context-menu/2.1.4.mdx
@@ -1543,8 +1543,6 @@ export default () => (
 
 ## Accessibility
 
-Uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
-
 ### Keyboard Interactions
 
 <KeyboardTable

--- a/data/primitives/docs/components/dropdown-menu/0.0.1.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.0.1.mdx
@@ -1139,7 +1139,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.0.17.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.0.17.mdx
@@ -1137,7 +1137,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.0.19.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.0.19.mdx
@@ -1126,7 +1126,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.0.22.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.0.22.mdx
@@ -974,7 +974,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.0.23.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.0.23.mdx
@@ -962,7 +962,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.0.7.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.0.7.mdx
@@ -1271,7 +1271,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.0.8.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.0.8.mdx
@@ -1282,7 +1282,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.1.0.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.1.0.mdx
@@ -1046,7 +1046,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/0.1.6.mdx
+++ b/data/primitives/docs/components/dropdown-menu/0.1.6.mdx
@@ -1071,7 +1071,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/1.0.0.mdx
+++ b/data/primitives/docs/components/dropdown-menu/1.0.0.mdx
@@ -1493,7 +1493,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/2.0.2.mdx
+++ b/data/primitives/docs/components/dropdown-menu/2.0.2.mdx
@@ -1524,7 +1524,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/2.0.5.mdx
+++ b/data/primitives/docs/components/dropdown-menu/2.0.5.mdx
@@ -1615,7 +1615,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dropdown-menu/2.0.5.mdx
+++ b/data/primitives/docs/components/dropdown-menu/2.0.5.mdx
@@ -1615,7 +1615,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton).
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/menubar/1.0.0.mdx
+++ b/data/primitives/docs/components/menubar/1.0.0.mdx
@@ -1580,7 +1580,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/menubar/1.0.3.mdx
+++ b/data/primitives/docs/components/menubar/1.0.3.mdx
@@ -1671,7 +1671,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/kbd_roving_tabindex) to manage focus movement among menu items.
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/menubar/1.0.3.mdx
+++ b/data/primitives/docs/components/menubar/1.0.3.mdx
@@ -1671,7 +1671,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton).
+Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubutton) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) to manage focus movement among menu items.
 
 ### Keyboard Interactions
 


### PR DESCRIPTION
Some accessibility links were broken and have been fixed. The `roving tabindex` link was Not Found and has been removed. If there is an alternative link I will change it.

I have one question. Should I change past documents as well?

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
