### PR TITLE
Add Responsive Columns Example to Grid Component Documentation

### DIFF
--- a/data/themes/docs/components/grid.mdx
+++ b/data/themes/docs/components/grid.mdx
@@ -38,3 +38,34 @@ Use these props to create grid layouts.
 The following props are shared between [Box](./box), [Flex](./flex), [Grid](./grid), [Container](./container) and [Section](./section) layout components.
 
 <ThemesPropsTable name="layout" />
+
+## Examples
+
+### Columns
+
+The `columns` prop can also accept an object to create responsive layouts.
+
+```jsx live=true
+<Grid columns={{ initial: '1', md: '2'}} gap="3" width="auto">
+  <Box height="9">
+    <DecorativeBox />
+  </Box>
+  <Box height="9">
+    <DecorativeBox />
+  </Box>
+  <Box height="9">
+    <DecorativeBox />
+  </Box>
+  <Box height="9">
+    <DecorativeBox />
+  </Box>
+  <Box height="9">
+    <DecorativeBox />
+  </Box>
+  <Box height="9">
+    <DecorativeBox />
+  </Box>
+</Grid>
+```
+
+In above example will create a grid with 1 column on smaller screens and 2 columns from the md breakpoint.

--- a/data/themes/docs/components/grid.mdx
+++ b/data/themes/docs/components/grid.mdx
@@ -45,20 +45,10 @@ The following props are shared between [Box](./box), [Flex](./flex), [Grid](./gr
 
 The `columns` prop can also accept an object to create responsive layouts.
 
+This example will create a grid with 1 column on smaller screens and 2 columns from the medium breakpoint.
+
 ```jsx live=true
-<Grid columns={{ initial: '1', md: '2'}} gap="3" width="auto">
-  <Box height="9">
-    <DecorativeBox />
-  </Box>
-  <Box height="9">
-    <DecorativeBox />
-  </Box>
-  <Box height="9">
-    <DecorativeBox />
-  </Box>
-  <Box height="9">
-    <DecorativeBox />
-  </Box>
+<Grid columns={{ initial: '1', md: '2' }} gap="3" width="auto">
   <Box height="9">
     <DecorativeBox />
   </Box>
@@ -67,5 +57,3 @@ The `columns` prop can also accept an object to create responsive layouts.
   </Box>
 </Grid>
 ```
-
-In above example will create a grid with 1 column on smaller screens and 2 columns from the md breakpoint.


### PR DESCRIPTION
This PR updates the Grid component documentation to include an example of how to use the `columns` prop to create a responsive grid layout. This important information was missing from the original documentation, and this update will make it clear to users how they can use the Grid component to create responsive layouts.

### Why is this important?

While using the Radix UI Themes documentation, it was not immediately clear that the Grid component supports responsive column layouts. This could lead other users to believe that this feature is not supported, potentially causing them to write more complex code or use additional libraries to achieve this functionality.

By including an example of responsive columns in the documentation, we can clearly demonstrate that this feature is supported out of the box. This will help users understand the full capabilities of the Grid component, allowing them to write more efficient and effective code.

This important information was missing from the original documentation, and this update will make it clear to users how they can use the Grid component to create responsive layouts.

### This pull request:

- [ ] Fixes a bug
- [X] Adds additional features/functionality
- [X] Updates documentation or example code
- [ ] Other
