### PR TITLE
docs: callout component usage documentation 

### DIFF
--- a/data/themes/docs/components/callout.mdx
+++ b/data/themes/docs/components/callout.mdx
@@ -5,11 +5,14 @@ sourcePath: components/callout
 ---
 
 ```jsx live=true
-<Callout.Root>
-  <Callout.Icon>
+// import references
+import { CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
+
+<CalloutRoot>
+  <CalloutIcon>
     <InfoCircledIcon />
-  </Callout.Icon>
-  <Callout.Text>
+  </CalloutIcon>
+  <CalloutText>
     You will need admin privileges to install and access this application.
   </Callout.Text>
 </Callout.Root>
@@ -38,33 +41,37 @@ Renders the callout text. This component is based on the `p` element.
 Use the `size` prop to control the size.
 
 ```jsx live=true
+// import references
+import { Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
+import {InfoCircledIcon} from "@radix-ui/react-icons";
+
 <Flex direction="column" gap="3" align="start">
-  <Callout.Root size="3">
-    <Callout.Icon>
+  <CalloutRoot size="3">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need admin privileges to install and access this application.
     </Callout.Text>
   </Callout.Root>
 
-  <Callout.Root size="2">
-    <Callout.Icon>
+  <CalloutRoot size="2">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need admin privileges to install and access this application.
     </Callout.Text>
-  </Callout.Root>
+  </CalloutRoot>
 
-  <Callout.Root size="1">
-    <Callout.Icon>
+  <CalloutRoot size="1">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need admin privileges to install and access this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 </Flex>
 ```
 
@@ -73,36 +80,40 @@ Use the `size` prop to control the size.
 Use the `variant` prop to control the visual style.
 
 ```jsx live=true
+// import references
+import { Link, Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
+import {InfoCircledIcon} from "@radix-ui/react-icons";
+
 <Flex direction="column" gap="3">
-  <Callout.Root variant="soft">
-    <Callout.Icon>
+  <CalloutRoot variant="soft">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need <Link href="#">admin privileges</Link> to install and access
       this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 
-  <Callout.Root variant="surface">
-    <Callout.Icon>
+  <CalloutRoot variant="surface">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need <Link href="#">admin privileges</Link> to install and access
       this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 
-  <Callout.Root variant="outline">
-    <Callout.Icon>
+  <CalloutRoot variant="outline">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need <Link href="#">admin privileges</Link> to install and access
       this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 </Flex>
 ```
 
@@ -111,36 +122,40 @@ Use the `variant` prop to control the visual style.
 Use the `color` prop to assign a specific [color](/themes/docs/theme/color), ignoring the global theme.
 
 ```jsx live=true
+// import references
+import { Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
+import {InfoCircledIcon} from "@radix-ui/react-icons";
+
 <Flex direction="column" gap="3">
-  <Callout.Root color="blue">
-    <Callout.Icon>
+  <CalloutRoot color="blue">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need <Link href="#">admin privileges</Link> to install and access
       this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 
-  <Callout.Root color="green">
-    <Callout.Icon>
+  <CalloutRoot color="green">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need <Link href="#">admin privileges</Link> to install and access
       this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 
-  <Callout.Root color="red">
-    <Callout.Icon>
+  <CalloutRoot color="red">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       You will need <Link href="#">admin privileges</Link> to install and access
       this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 </Flex>
 ```
 
@@ -149,24 +164,28 @@ Use the `color` prop to assign a specific [color](/themes/docs/theme/color), ign
 Use the `HighContrast` prop to add additional contrast.
 
 ```jsx live=true
-<Flex direction="column" gap="3">
-  <Callout.Root variant="soft">
-    <Callout.Icon>
-      <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
-      An update to Radix Themes is available. See what’s new in version 3.2.0.
-    </Callout.Text>
-  </Callout.Root>
+// import references
+import { Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
+import {InfoCircledIcon} from "@radix-ui/react-icons";
 
-  <Callout.Root variant="soft" highContrast>
-    <Callout.Icon>
+<Flex direction="column" gap="3">
+  <CalloutRoot variant="soft">
+    <CalloutIcon>
       <InfoCircledIcon />
-    </Callout.Icon>
-    <Callout.Text>
+    </CalloutIcon>
+    <CalloutText>
       An update to Radix Themes is available. See what’s new in version 3.2.0.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
+
+  <CalloutRoot variant="soft" highContrast>
+    <CalloutIcon>
+      <InfoCircledIcon />
+    </CalloutIcon>
+    <CalloutText>
+      An update to Radix Themes is available. See what’s new in version 3.2.0.
+    </CalloutText>
+  </CalloutRoot>
 </Flex>
 ```
 
@@ -175,12 +194,16 @@ Use the `HighContrast` prop to add additional contrast.
 Add a native [WAI-ARIA `alert` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) to the callout when the user’s immediate attention is required, like when an error message appears. The screen reader will be interrupted, announcing the new content immediately.
 
 ```jsx live=true
-<Callout.Root color="red" role="alert">
-  <Callout.Icon>
+// import references
+import { CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
+import {ExclamationTriangleIcon} from "@radix-ui/react-icons";
+
+<CalloutRoot color="red" role="alert">
+  <CalloutIcon>
     <ExclamationTriangleIcon />
-  </Callout.Icon>
-  <Callout.Text>
+  </CalloutIcon>
+  <CalloutText>
     Access denied. Please contact the network administrator to view this page.
-  </Callout.Text>
-</Callout.Root>
+  </CalloutText>
+</CalloutRoot>
 ```

--- a/data/themes/docs/components/callout.mdx
+++ b/data/themes/docs/components/callout.mdx
@@ -5,8 +5,7 @@ sourcePath: components/callout
 ---
 
 ```jsx live=true
-// import references
-import { CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
+import { CalloutRoot, CalloutIcon, CalloutText } from '@radix-ui/themes';
 
 <CalloutRoot>
   <CalloutIcon>
@@ -14,8 +13,8 @@ import { CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
   </CalloutIcon>
   <CalloutText>
     You will need admin privileges to install and access this application.
-  </Callout.Text>
-</Callout.Root>
+  </CalloutText>
+</CalloutRoot>;
 ```
 
 ## API Reference
@@ -41,9 +40,8 @@ Renders the callout text. This component is based on the `p` element.
 Use the `size` prop to control the size.
 
 ```jsx live=true
-// import references
-import { Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
-import {InfoCircledIcon} from "@radix-ui/react-icons";
+import { Flex, CalloutRoot, CalloutIcon, CalloutText } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
 
 <Flex direction="column" gap="3" align="start">
   <CalloutRoot size="3">
@@ -52,8 +50,8 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
     </CalloutIcon>
     <CalloutText>
       You will need admin privileges to install and access this application.
-    </Callout.Text>
-  </Callout.Root>
+    </CalloutText>
+  </CalloutRoot>
 
   <CalloutRoot size="2">
     <CalloutIcon>
@@ -61,7 +59,7 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
     </CalloutIcon>
     <CalloutText>
       You will need admin privileges to install and access this application.
-    </Callout.Text>
+    </CalloutText>
   </CalloutRoot>
 
   <CalloutRoot size="1">
@@ -72,7 +70,7 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
       You will need admin privileges to install and access this application.
     </CalloutText>
   </CalloutRoot>
-</Flex>
+</Flex>;
 ```
 
 ### Variant
@@ -80,9 +78,14 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
 Use the `variant` prop to control the visual style.
 
 ```jsx live=true
-// import references
-import { Link, Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
-import {InfoCircledIcon} from "@radix-ui/react-icons";
+import {
+  Link,
+  Flex,
+  CalloutRoot,
+  CalloutIcon,
+  CalloutText,
+} from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
 
 <Flex direction="column" gap="3">
   <CalloutRoot variant="soft">
@@ -114,7 +117,7 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
       this application.
     </CalloutText>
   </CalloutRoot>
-</Flex>
+</Flex>;
 ```
 
 ### Color
@@ -122,9 +125,8 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
 Use the `color` prop to assign a specific [color](/themes/docs/theme/color), ignoring the global theme.
 
 ```jsx live=true
-// import references
-import { Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
-import {InfoCircledIcon} from "@radix-ui/react-icons";
+import { Flex, CalloutRoot, CalloutIcon, CalloutText } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
 
 <Flex direction="column" gap="3">
   <CalloutRoot color="blue">
@@ -156,7 +158,7 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
       this application.
     </CalloutText>
   </CalloutRoot>
-</Flex>
+</Flex>;
 ```
 
 ### High-contrast
@@ -164,9 +166,8 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
 Use the `HighContrast` prop to add additional contrast.
 
 ```jsx live=true
-// import references
-import { Flex, CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
-import {InfoCircledIcon} from "@radix-ui/react-icons";
+import { Flex, CalloutRoot, CalloutIcon, CalloutText } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
 
 <Flex direction="column" gap="3">
   <CalloutRoot variant="soft">
@@ -186,7 +187,7 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
       An update to Radix Themes is available. See what’s new in version 3.2.0.
     </CalloutText>
   </CalloutRoot>
-</Flex>
+</Flex>;
 ```
 
 ### As alert
@@ -194,9 +195,8 @@ import {InfoCircledIcon} from "@radix-ui/react-icons";
 Add a native [WAI-ARIA `alert` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) to the callout when the user’s immediate attention is required, like when an error message appears. The screen reader will be interrupted, announcing the new content immediately.
 
 ```jsx live=true
-// import references
-import { CalloutRoot, CalloutIcon, CalloutText } from "@radix-ui/themes";
-import {ExclamationTriangleIcon} from "@radix-ui/react-icons";
+import { CalloutRoot, CalloutIcon, CalloutText } from '@radix-ui/themes';
+import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 
 <CalloutRoot color="red" role="alert">
   <CalloutIcon>
@@ -205,5 +205,5 @@ import {ExclamationTriangleIcon} from "@radix-ui/react-icons";
   <CalloutText>
     Access denied. Please contact the network administrator to view this page.
   </CalloutText>
-</CalloutRoot>
+</CalloutRoot>;
 ```


### PR DESCRIPTION
This forms the foundation of many changes to come, the docs do not specify what imports are needed to use a component, the previous examples are similar to  [Primitives](https://www.radix-ui.com/primitives/docs/overview/introduction) and not compatible with the new theme system using `@radix-ui/themes` .


Before :
<img width="737" alt="Screenshot 2024-03-12 at 16 19 04" src="https://github.com/radix-ui/website/assets/8831475/8beb11c1-84f9-4021-9e33-be1b02943050">



After:
<img width="733" alt="Screenshot 2024-03-12 at 16 31 08" src="https://github.com/radix-ui/website/assets/8831475/dd6908a2-662e-461a-a8db-8158fc7f369c">


<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
