### PR TITLE
Color generator fast follow-ups

### DIFF
--- a/components/generateRadixColors.tsx
+++ b/components/generateRadixColors.tsx
@@ -91,9 +91,7 @@ export const generateRadixColors = ({
     color.to('srgb').toString({ format: 'hex' })
   ) as ArrayOf12<string>;
 
-  const accentScaleWideGamut = accentScaleColors.map((color) =>
-    color.to('oklch').toString({ precision: 4 })
-  ) as ArrayOf12<string>;
+  const accentScaleWideGamut = accentScaleColors.map(toOklchString) as ArrayOf12<string>;
 
   const accentScaleAlphaHex = accentScaleHex.map((color) =>
     getAlphaColorSrgb(color, backgroundHex)
@@ -109,9 +107,7 @@ export const generateRadixColors = ({
     color.to('srgb').toString({ format: 'hex' })
   ) as ArrayOf12<string>;
 
-  const grayScaleWideGamut = grayScaleColors.map((color) =>
-    color.to('oklch').toString({ precision: 4 })
-  ) as ArrayOf12<string>;
+  const grayScaleWideGamut = grayScaleColors.map(toOklchString) as ArrayOf12<string>;
 
   const grayScaleAlphaHex = grayScaleHex.map((color) =>
     getAlphaColorSrgb(color, backgroundHex)
@@ -574,4 +570,14 @@ export function transposeProgressionEnd(
     const fn = BezierEasing(...curve);
     return n - diff * fn(i / lastIndex);
   });
+}
+
+// Convert to OKLCH string with percentage for the lightness channel
+// https://github.com/radix-ui/themes/issues/420
+function toOklchString(color: Color) {
+  const L = +(color.coords[0] * 100).toFixed(1);
+  return color
+    .to('oklch')
+    .toString({ precision: 4 })
+    .replace(/(\S+)(.+)/, `oklch(${L}%$2`);
 }

--- a/data/colors/docs/overview/custom-palettes.mdx
+++ b/data/colors/docs/overview/custom-palettes.mdx
@@ -1,0 +1,32 @@
+---
+metaTitle: Custom palettes
+metaDescription: How to create custom Radix Colors palettes.
+---
+
+# Custom palettes
+
+<Description>Learn how to create custom Radix Colors palettes.</Description>
+
+Use the [custom color palette tool](/colors/custom) to generate a Radix Colors scale based just on a couple reference colors. Once you are happy with the result, paste the generated CSS into your project and use them the same way you would use the regular Radix Colors scales.
+
+The generated scales are based on the Radix Colors scales themselves, so they will work well with similar component designs. As long as you use a reasonable background color, the contrast ratios will be similar to what Radix Colors provide.
+
+## What you get
+
+Your custom color palette will Radix Colors steps 1 through 12, as well as their alpha variants and wide-gamut color definitions. Wide-gamut color definitions are needed to ensure that alpha colors are displayed with full saturation in wide-gamut color spaces, such as on Apple’s displays that support P3. This is because alpha blending works differently in P3 than in sRGB.
+
+Learn about the base palette composition in the [Understanding the scale](/colors/docs/palette-composition/understanding-the-scale) guide. The generated CSS also includes a few extra colors used exclusively in [Radix Themes](/themes/docs), such as:
+
+- Surface color, used by certain `variant="surface"` components
+- Indicator color, used by components like Checkbox, Radio, and Tabs
+- Track color, used by components like Slider and Progress Bar
+
+Feel free to remove colors from the generated CSS that you don’t need.
+
+## Color formats
+
+You can use any common CSS color format in the input fields, or even wide-gamut color spaces, such as `color(display-p3 1 0.5 0)`. The generated CSS will provide the closest sRGB fallbacks.
+
+## Dark theme
+
+To generate dark theme colors, toggle the appearance to dark in the website header. Make sure to paste the generated CSS after your light theme color overrides.

--- a/data/colors/docs/overview/custom-palettes.mdx
+++ b/data/colors/docs/overview/custom-palettes.mdx
@@ -13,7 +13,7 @@ The generated scales are based on the Radix Colors scales themselves, so they wi
 
 ## What you get
 
-Your custom color palette will Radix Colors steps 1 through 12, as well as their alpha variants and wide-gamut color definitions. Wide-gamut color definitions are needed to ensure that alpha colors are displayed with full saturation in wide-gamut color spaces, such as on Apple’s displays that support P3. This is because alpha blending works differently in P3 than in sRGB.
+Your custom color palette will include Radix Colors steps 1 through 12, as well as their alpha variants and wide-gamut color definitions. Wide-gamut color definitions are needed to ensure that alpha colors are displayed with full saturation in wide-gamut color spaces, such as on Apple’s displays that support P3. This is because alpha blending works differently in P3 than in sRGB.
 
 Learn about the base palette composition in the [Understanding the scale](/colors/docs/palette-composition/understanding-the-scale) guide. The generated CSS also includes a few extra colors used exclusively in [Radix Themes](/themes/docs), such as:
 

--- a/data/colors/docs/palette-composition/understanding-the-scale.mdx
+++ b/data/colors/docs/palette-composition/understanding-the-scale.mdx
@@ -1,5 +1,5 @@
 ---
-metaTitle: Use Cases
+metaTitle: Use cases
 metaDescription: How to use Radix Colors.
 ---
 
@@ -9,7 +9,7 @@ metaDescription: How to use Radix Colors.
   Learn which scale step is the most appropriate for each use case.
 </Description>
 
-## Use Cases
+## Use cases
 
 There are 12 steps in each scale. Each step was designed for at least one specific use case.
 

--- a/data/themes/docs/theme/color.mdx
+++ b/data/themes/docs/theme/color.mdx
@@ -318,7 +318,7 @@ In this example, using solid-colored `indigo` components will now reference your
 
 You can use the [custom color palette tool](/colors/custom) to generate a custom palette based just on a couple reference colors. Once you are happy with the result, paste the generated CSS into your project. You can rename the generated colors to match the accent that you want to use in your theme.
 
-To generate dark theme colors, toggle the appearance to dark in the website header. Make sure to paste the generated CSS after your light theme color overrides.
+To generate dark theme colors, toggle the appearance to use the dark theme. Make sure to paste the generated CSS after your light theme color overrides.
 
 <Text as="div" align="center" my="6">
   <Box asChild mb="2">

--- a/pages/colors/custom.tsx
+++ b/pages/colors/custom.tsx
@@ -87,6 +87,21 @@ export default function Page() {
   const [darkGrayValue, setDarkGrayValue] = useLocalStorage('colors/dark/gray', '#8B8D98');
   const [darkBgValue, setDarkBgValue] = useLocalStorage('colors/dark/background', '#111111');
 
+  // Discard local storage values that are older than 2 hours
+  const [timestamp, setTimestamp] = useLocalStorage('colors/timestamp', Date.now());
+  const [discardStoredValues] = React.useState(Date.now() - timestamp > 1000 * 60 * 2);
+  useIsomorphicLayoutEffect(() => {
+    if (discardStoredValues) {
+      setTimestamp(Date.now());
+      setLightAccentValue('#3D63DD');
+      setLightGrayValue('#8B8D98');
+      setLightBgValue('#FFFFFF');
+      setDarkAccentValue('#3D63DD');
+      setDarkGrayValue('#8B8D98');
+      setDarkBgValue('#111111');
+    }
+  }, [discardStoredValues]);
+
   const accentValue = resolvedTheme === 'dark' ? darkAccentValue : lightAccentValue;
   const grayValue = resolvedTheme === 'dark' ? darkGrayValue : lightGrayValue;
   const bgValue = resolvedTheme === 'dark' ? darkBgValue : lightBgValue;
@@ -184,7 +199,7 @@ export default function Page() {
               </Heading>
 
               <SegmentedControl.Root
-                value={resolvedTheme}
+                value={resolvedTheme === 'dark' ? 'dark' : 'light'}
                 onValueChange={setTheme}
                 style={{ backgroundColor: 'transparent' }}
                 mt="5"

--- a/pages/colors/custom.tsx
+++ b/pages/colors/custom.tsx
@@ -28,7 +28,8 @@ import {
   CopyIcon,
   FigmaLogoIcon,
   ArrowLeftIcon,
-  ArrowRightIcon,
+  SunIcon,
+  MoonIcon,
 } from '@radix-ui/react-icons';
 import {
   Avatar,
@@ -50,6 +51,7 @@ import {
   Link,
   Reset,
   Section,
+  SegmentedControl,
   Separator,
   Strong,
   Switch,
@@ -75,15 +77,15 @@ import { ColorUsageRange } from '@components/ColorUsageRange';
 import { ColorStepLabel } from '@components/ColorStepLabel';
 
 export default function Page() {
-  const { resolvedTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
 
-  const [lightAccentValue, setLightAccentValue] = useLocalStorage('create/light/accent', '#3D63DD');
-  const [lightGrayValue, setLightGrayValue] = useLocalStorage('create/light/gray', '#8B8D98');
-  const [lightBgValue, setLightBgValue] = useLocalStorage('create/light/background', '#FFFFFF');
+  const [lightAccentValue, setLightAccentValue] = useLocalStorage('colors/light/accent', '#3D63DD');
+  const [lightGrayValue, setLightGrayValue] = useLocalStorage('colors/light/gray', '#8B8D98');
+  const [lightBgValue, setLightBgValue] = useLocalStorage('colors/light/background', '#FFFFFF');
 
-  const [darkAccentValue, setDarkAccentValue] = useLocalStorage('create/dark/accent', '#3D63DD');
-  const [darkGrayValue, setDarkGrayValue] = useLocalStorage('create/dark/gray', '#8B8D98');
-  const [darkBgValue, setDarkBgValue] = useLocalStorage('create/dark/background', '#111111');
+  const [darkAccentValue, setDarkAccentValue] = useLocalStorage('colors/dark/accent', '#3D63DD');
+  const [darkGrayValue, setDarkGrayValue] = useLocalStorage('colors/dark/gray', '#8B8D98');
+  const [darkBgValue, setDarkBgValue] = useLocalStorage('colors/dark/background', '#111111');
 
   const accentValue = resolvedTheme === 'dark' ? darkAccentValue : lightAccentValue;
   const grayValue = resolvedTheme === 'dark' ? darkGrayValue : lightGrayValue;
@@ -168,8 +170,8 @@ export default function Page() {
 
         <Section px={{ initial: '5', xs: '6', sm: '7', md: '9' }} size={{ initial: '2', md: '3' }}>
           <Container position="relative">
-            <Flex direction="column" align="center" gap="3" mb="8">
-              <Flex asChild align="center" gap="1">
+            <Flex direction="column" align="center" mb="7">
+              <Flex asChild align="center" gap="1" mb="3">
                 <Link asChild size="2" color="gray" ml="-2">
                   <NextLink href="/colors">
                     <ArrowLeftIcon />
@@ -180,14 +182,26 @@ export default function Page() {
               <Heading as="h1" align="center" size="8">
                 Create a custom palette
               </Heading>
-              {/* <Flex asChild align="center" gap="1">
-                <Link asChild size="2" color="gray" ml="-2">
-                  <NextLink href="/colors/docs/overview/custom">
-                    How to use custom colors
-                    <ArrowRightIcon />
-                  </NextLink>
-                </Link>
-              </Flex> */}
+
+              <SegmentedControl.Root
+                value={resolvedTheme}
+                onValueChange={setTheme}
+                style={{ backgroundColor: 'transparent' }}
+                mt="5"
+              >
+                <SegmentedControl.Item value="light">
+                  <Flex as="span" align="center" gap="2" ml="-1">
+                    <SunIcon />
+                    Light
+                  </Flex>
+                </SegmentedControl.Item>
+                <SegmentedControl.Item value="dark">
+                  <Flex as="span" align="center" gap="2" ml="-1">
+                    <MoonIcon />
+                    Dark
+                  </Flex>
+                </SegmentedControl.Item>
+              </SegmentedControl.Root>
             </Flex>
 
             <Box mb="9">
@@ -248,21 +262,6 @@ export default function Page() {
                       </Button>
                     </DropdownMenu.Trigger>
                     <DropdownMenu.Content>
-                      {/*
-                        <DropdownMenu.Item
-                          onSelect={() => {
-                            setCopied(true);
-                            setSvgCopied(false);
-                            clearTimeout(copiedTimeoutRef.current);
-                            copiedTimeoutRef.current = setTimeout(() => {
-                              setCopied(false);
-                            }, COPIED_TIMEOUT);
-                          }}
-                        >
-                          Copy CSS code
-                        </DropdownMenu.Item>
-                      */}
-
                       <DropdownMenu.Sub>
                         <DropdownMenu.SubTrigger>
                           <Flex align="center" gap="2">

--- a/pages/colors/custom.tsx
+++ b/pages/colors/custom.tsx
@@ -92,7 +92,6 @@ export default function Page() {
   const [discardStoredValues] = React.useState(Date.now() - timestamp > 1000 * 60 * 2);
   useIsomorphicLayoutEffect(() => {
     if (discardStoredValues) {
-      setTimestamp(Date.now());
       setLightAccentValue('#3D63DD');
       setLightGrayValue('#8B8D98');
       setLightBgValue('#FFFFFF');
@@ -100,6 +99,8 @@ export default function Page() {
       setDarkGrayValue('#8B8D98');
       setDarkBgValue('#111111');
     }
+    // Refresh the timestamp
+    setTimestamp(Date.now());
   }, [discardStoredValues]);
 
   const accentValue = resolvedTheme === 'dark' ? darkAccentValue : lightAccentValue;

--- a/utils/colorsRoutes.ts
+++ b/utils/colorsRoutes.ts
@@ -18,6 +18,11 @@ export const colorsRoutes = [
         draft: false,
       },
       {
+        title: 'Custom palettes',
+        slug: 'colors/docs/overview/custom-palettes',
+        draft: false,
+      },
+      {
         title: 'Releases',
         slug: 'colors/docs/overview/releases',
         draft: false,


### PR DESCRIPTION
- Use percentage for OKLCH string lightness (https://github.com/radix-ui/themes/issues/420)
- Add a guide on custom palettes
- Add a more prominent theme toggle
- Discard local storage values that are older than 2 hours