### PR TITLE
Fix: Correct default value for 'dir' prop in primitives/docs/components/tabs

### DIFF
--- a/data/primitives/docs/components/tabs/1.0.4.mdx
+++ b/data/primitives/docs/components/tabs/1.0.4.mdx
@@ -114,6 +114,7 @@ Contains all the tabs component parts.
       required: false,
       type: '"ltr" | "rtl"',
       typeSimple: 'enum',
+      default: '"ltr"',
       description: (
         <span>
           The reading direction of the tabs. If omitted, inherits globally from{' '}


### PR DESCRIPTION
Hi
It seems that the default value of `dir` is not written correctly
 in https://www.radix-ui.com/primitives/docs/components/tabs


![Screenshot_2024-04-23_13_12_08](https://github.com/radix-ui/website/assets/17986464/e7352dae-2945-44bd-910d-f0beb32191ae)


This pull request:
- [x] Updates documentation or example code

