### PR TITLE
Adjust the ExampleThemes* page layout

### DIFF
--- a/components/ExampleThemesDashboard.tsx
+++ b/components/ExampleThemesDashboard.tsx
@@ -61,7 +61,7 @@ export const ExampleThemesDashboard = ({ focusable = true, ...props }: ExampleLa
   });
 
   return (
-    <Flex align="center" gap="6" ref={setPortalContainer} {...props}>
+    <Flex align="center" wrap="wrap" gap="6" ref={setPortalContainer} {...props}>
       <Flex flexShrink="0" gap="6" direction="column" width="640px">
         <Card size="4">
           <Heading as="h3" size="6" trim="start" mb="2">

--- a/components/ExampleThemesEcommerce.tsx
+++ b/components/ExampleThemesEcommerce.tsx
@@ -64,7 +64,7 @@ export const ExampleThemesEcommerce = ({ focusable = true, ...props }: ExampleLa
   });
 
   return (
-    <Flex align="center" gap="6" ref={setPortalContainer} {...props}>
+    <Flex align="center" wrap="wrap" gap="6" ref={setPortalContainer} {...props}>
       <Flex flexShrink="0" gap="6" direction="column" width="304px">
         <Card size="1">
           <Flex mb="2">

--- a/components/ExampleThemesMusicApp.tsx
+++ b/components/ExampleThemesMusicApp.tsx
@@ -48,7 +48,7 @@ export const ExampleThemesMusicApp = ({ focusable = true, ...props }: ExampleLay
         </style>
       </Head>
 
-      <Flex align="center" gap="6" {...props}>
+      <Flex align="center" wrap="wrap" gap="6" {...props}>
         <Flex flexShrink="0" gap="6" direction="column" width="416px">
           <Card size="3">
             <Flex align="center" justify="between" mb="5">


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

---

Hey y'all 👋 This is not a functional bug per se, but more of a design issue that I noticed while browsing through these ExampleThemes* components/pages on a small viewport: they bleed off of it, get a horizontal scroll, and the background/title get off-center. The video below illustrates all of this better + the fix (which was just adding `wrap` to the Flex parent containers):


https://github.com/radix-ui/website/assets/67129314/d7f18215-7906-4109-87a2-f7da494286db

