### PR TITLE
Add `ctrl/cmd + k` Keyboard Shortcut

### DIFF
--- a/components/PrimitivesSearchDesktop.tsx
+++ b/components/PrimitivesSearchDesktop.tsx
@@ -19,7 +19,10 @@ export const PrimitivesSearchDesktop = () => {
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (!isEditingContent(event) && event.key === '/') {
+      const isSlashKey = event.key === '/';
+      const isMetaKey = event.key === 'k' && (event.ctrlKey || event.metaKey);
+
+      if (!isEditingContent(event) && (isSlashKey || isMetaKey)) {
         triggerRef.current.click();
         event.preventDefault();
       }


### PR DESCRIPTION
Added support for `ctrl/cmd + k` keyboard support for opening the search dialog in the primitives docs (https://www.radix-ui.com/primitives/docs/overview/introduction). This is probably the most common keyboard shortcut on most doc sites.

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [x] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
