### PR TITLE
Update 1.1.3.mdx - Fix WAI-ARIA RadioGroup pattern url

### DIFF
--- a/data/primitives/docs/components/radio-group/1.2.0.mdx
+++ b/data/primitives/docs/components/radio-group/1.2.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -280,7 +280,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 


### PR DESCRIPTION
The current link is leading to a [Document not found](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) page.
This PR fixes it with the right pattern url.

Preview link to test the fix: https://radix-website-git-fork-federico-rimembrana-patch-1-workos.vercel.app/themes/docs/components/radio-group

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
