### PR TITLE
Update W3 link in the Tabs documentation to not lead to a 404 page

### DIFF
--- a/data/primitives/docs/components/tabs/1.0.4.mdx
+++ b/data/primitives/docs/components/tabs/1.0.4.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that are displayed one at a time.
 name: tabs
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs
 ---
 
 # Tabs

--- a/data/primitives/docs/components/tabs/1.0.4.mdx
+++ b/data/primitives/docs/components/tabs/1.0.4.mdx
@@ -332,7 +332,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs).
 
 ### Keyboard Interactions
 


### PR DESCRIPTION
The W3 Link on the Tabs component currently leads to a [404 page](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel). The [updated link](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) leads to the correct Tabs WAI-ARIA design pattern docs. [Preview URL](https://vercel.live/open-feedback/radix-website-git-fork-lukebrobbs-patch-1-workos.vercel.app?via=pr-comment-visit-preview-link&passThrough=1)

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code.
- [X] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other