### PR TITLE
Fix W3C Broken Links

### DIFF
--- a/data/primitives/docs/components/dialog/0.0.1.mdx
+++ b/data/primitives/docs/components/dialog/0.0.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -278,7 +278,7 @@ The button that closes the dialog.
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.0.17.mdx
+++ b/data/primitives/docs/components/dialog/0.0.17.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -272,7 +272,7 @@ The button that closes the dialog.
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.0.18.mdx
+++ b/data/primitives/docs/components/dialog/0.0.18.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -272,7 +272,7 @@ The button that closes the dialog.
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.0.19.mdx
+++ b/data/primitives/docs/components/dialog/0.0.19.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -261,7 +261,7 @@ An accessible description to be announced when the dialog is opened. Alternative
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.0.20.mdx
+++ b/data/primitives/docs/components/dialog/0.0.20.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -287,7 +287,7 @@ An accessible description to be announced when the dialog is opened. Alternative
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.0.6.mdx
+++ b/data/primitives/docs/components/dialog/0.0.6.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -326,7 +326,7 @@ The button that closes the dialog.
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.1.0.mdx
+++ b/data/primitives/docs/components/dialog/0.1.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -329,7 +329,7 @@ An accessible description to be announced when the dialog is opened. Alternative
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.1.1.mdx
+++ b/data/primitives/docs/components/dialog/0.1.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -354,7 +354,7 @@ An accessible description to be announced when the dialog is opened. Alternative
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.1.5.mdx
+++ b/data/primitives/docs/components/dialog/0.1.5.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -443,7 +443,7 @@ export default () => {
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/0.1.7.mdx
+++ b/data/primitives/docs/components/dialog/0.1.7.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -447,7 +447,7 @@ export default () => {
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/dialog/1.1.1.mdx
+++ b/data/primitives/docs/components/dialog/1.1.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Dialog
 metaDescription: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 name: dialog
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Dialog
@@ -513,7 +513,7 @@ export default () => {
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.0.1.mdx
+++ b/data/primitives/docs/components/popover/0.0.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -466,7 +466,7 @@ const StyledContent = styled(Popover.Content, {
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.0.15.mdx
+++ b/data/primitives/docs/components/popover/0.0.15.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -466,7 +466,7 @@ const StyledContent = styled(Popover.Content, {
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.0.17.mdx
+++ b/data/primitives/docs/components/popover/0.0.17.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -517,7 +517,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.0.19.mdx
+++ b/data/primitives/docs/components/popover/0.0.19.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -498,7 +498,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.0.20.mdx
+++ b/data/primitives/docs/components/popover/0.0.20.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -477,7 +477,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.0.6.mdx
+++ b/data/primitives/docs/components/popover/0.0.6.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -514,7 +514,7 @@ const StyledContent = styled(Popover.Content, {
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.1.0.mdx
+++ b/data/primitives/docs/components/popover/0.1.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -512,7 +512,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/0.1.6.mdx
+++ b/data/primitives/docs/components/popover/0.1.6.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -537,7 +537,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/1.0.3.mdx
+++ b/data/primitives/docs/components/popover/1.0.3.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -634,7 +634,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/popover/1.1.1.mdx
+++ b/data/primitives/docs/components/popover/1.1.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Popover
 metaDescription: Displays rich content in a portal, triggered by a button.
 name: popover
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal
 ---
 
 # Popover
@@ -691,7 +691,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/0.0.1.mdx
+++ b/data/primitives/docs/components/radio-group/0.0.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -246,7 +246,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/0.0.14.mdx
+++ b/data/primitives/docs/components/radio-group/0.0.14.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -246,7 +246,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/0.0.16.mdx
+++ b/data/primitives/docs/components/radio-group/0.0.16.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -269,7 +269,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/0.0.19.mdx
+++ b/data/primitives/docs/components/radio-group/0.0.19.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -204,7 +204,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/0.0.6.mdx
+++ b/data/primitives/docs/components/radio-group/0.0.6.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -282,7 +282,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/0.1.5.mdx
+++ b/data/primitives/docs/components/radio-group/0.1.5.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -225,7 +225,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/1.0.0.mdx
+++ b/data/primitives/docs/components/radio-group/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -255,7 +255,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/radio-group/1.2.0.mdx
+++ b/data/primitives/docs/components/radio-group/1.2.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Radio Group
 metaDescription: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 name: radio-group
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/radio
 ---
 
 # Radio Group
@@ -280,7 +280,7 @@ Renders when the radio item is in a checked state. You can style this element di
 
 ## Accessibility
 
-Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton) and uses [roving tabindex](https://www.w3.org/TR/wai-aria-practices-1.2/examples/radio/radio.html) to manage focus movement among radio items.
+Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio) and uses [roving tabindex](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio) to manage focus movement among radio items.
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/slider/0.0.1.mdx
+++ b/data/primitives/docs/components/slider/0.0.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Slider
 metaDescription: An input where the user selects a value from within a given range.
 name: slider
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb
 ---
 
 # Slider
@@ -498,7 +498,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb).
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/slider/0.0.17.mdx
+++ b/data/primitives/docs/components/slider/0.0.17.mdx
@@ -2,7 +2,7 @@
 metaTitle: Slider
 metaDescription: An input where the user selects a value from within a given range.
 name: slider
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb
 ---
 
 # Slider
@@ -288,7 +288,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb).
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/slider/0.0.5.mdx
+++ b/data/primitives/docs/components/slider/0.0.5.mdx
@@ -2,7 +2,7 @@
 metaTitle: Slider
 metaDescription: An input where the user selects a value from within a given range.
 name: slider
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb
 ---
 
 # Slider
@@ -546,7 +546,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb).
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/slider/0.1.4.mdx
+++ b/data/primitives/docs/components/slider/0.1.4.mdx
@@ -2,7 +2,7 @@
 metaTitle: Slider
 metaDescription: An input where the user selects a value from within a given range.
 name: slider
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb
 ---
 
 # Slider
@@ -316,7 +316,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb).
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/slider/1.0.0.mdx
+++ b/data/primitives/docs/components/slider/1.0.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Slider
 metaDescription: An input where the user selects a value from within a given range.
 name: slider
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb
 ---
 
 # Slider
@@ -372,7 +372,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb).
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/slider/1.2.0.mdx
+++ b/data/primitives/docs/components/slider/1.2.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Slider
 metaDescription: An input where the user selects a value from within a given range.
 name: slider
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb
 ---
 
 # Slider
@@ -437,7 +437,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slidertwothumb).
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/tabs/0.0.1.mdx
+++ b/data/primitives/docs/components/tabs/0.0.1.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that display one panel of content at a time.
 name: tabs
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs
 ---
 
 # Tabs
@@ -316,7 +316,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/tabs/0.0.13.mdx
+++ b/data/primitives/docs/components/tabs/0.0.13.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that display one panel of content at a time.
 name: tabs
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs
 ---
 
 # Tabs
@@ -325,7 +325,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/tabs/0.0.16.mdx
+++ b/data/primitives/docs/components/tabs/0.0.16.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that are displayed one at a time.
 name: tabs
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs
 ---
 
 # Tabs
@@ -236,7 +236,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/tabs/0.0.5.mdx
+++ b/data/primitives/docs/components/tabs/0.0.5.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that display one panel of content at a time.
 name: tabs
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs
 ---
 
 # Tabs
@@ -364,7 +364,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/tabs/0.1.5.mdx
+++ b/data/primitives/docs/components/tabs/0.1.5.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that are displayed one at a time.
 name: tabs
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs
 ---
 
 # Tabs
@@ -264,7 +264,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/components/tabs/1.1.0.mdx
+++ b/data/primitives/docs/components/tabs/1.1.0.mdx
@@ -2,7 +2,7 @@
 metaTitle: Tabs
 metaDescription: A set of layered sections of content—known as tab panels—that are displayed one at a time.
 name: tabs
-aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel
+aria: https://www.w3.org/WAI/ARIA/apg/patterns/tabs
 ---
 
 # Tabs
@@ -332,7 +332,7 @@ export default () => (
 
 ## Accessibility
 
-Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel).
+Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs).
 
 ### Keyboard Interactions
 

--- a/data/primitives/docs/overview/getting-started.mdx
+++ b/data/primitives/docs/overview/getting-started.mdx
@@ -108,7 +108,7 @@ These components are low-level enough to give you control over how you want to w
 
 In a few simple steps, we've implemented a fully accessible Popover component, without having to worry about many of its complexities.
 
-- Adheres to [WAI-ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal) design pattern.
+- Adheres to [WAI-ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal) design pattern.
 - Can be controlled or uncontrolled.
 - Customize side, alignment, offsets, collision handling.
 - Optionally render a pointing arrow.


### PR DESCRIPTION
## Description
This pull request seeks to update the broken W3C links in the primitive components documentation.

### Links affected
- [Getting Started](https://www.radix-ui.com/primitives/docs/overview/getting-started)
- [Popover](https://www.radix-ui.com/primitives/docs/components/popover)
- [Radio Group](https://www.radix-ui.com/primitives/docs/components/radio-group)
- [Slider](https://www.radix-ui.com/primitives/docs/components/slider)
- [Tabs](https://www.radix-ui.com/primitives/docs/components/tabs)

## PR Validation

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
