### PR TITLE
fix(docs): small typo in text-area.mdx

### DIFF
--- a/data/themes/docs/components/text-area.mdx
+++ b/data/themes/docs/components/text-area.mdx
@@ -72,7 +72,7 @@ Use the `radius` prop to assign a specific radius value.
 
 ### Resize
 
-Use the `resize` prop to enable resizing on one ore both axis.
+Use the `resize` prop to enable resizing on one or both axis.
 
 ```jsx live=true
 <Flex direction="column" gap="3" maxWidth="250px">


### PR DESCRIPTION
Fixes a small typo `ore` → `or` in `text-area.mdx`.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
