### PR TITLE
typo: missing space between `"app"` and `"now"` (hero)

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -231,7 +231,7 @@ const MainContent = () => (
           <SerifHeading mb="3">
             Start building
             <br />
-            your appnow
+            your app now
           </SerifHeading>
         </Box>
         <Box display={{ initial: 'none', lg: 'block' }}>
@@ -241,7 +241,7 @@ const MainContent = () => (
           >
             Start building
             <br />
-            your appnow
+            your app now
           </SerifHeading>
         </Box>
       </Box>


### PR DESCRIPTION
fixes #803 by adding missing space between `"app"` and `"now"` in hero ([`/`](https://radix-ui.com/))

- [x] use a meaningful title for the pull request. include the name of the package modified
- [x] test the change in your own code
- [x] include the URL where we can test the change in the body of your pr

this pull request:

- [ ] fixes a bug
- [ ] adds additional features/functionality
- [x] updates documentation or example code
- [ ] other
