### PR TITLE
Add accessibility name to github link in header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -141,9 +141,9 @@ export const Header = ({ children, gitHubLink, ghost }: HeaderProps) => {
               </Link>
 
               {gitHubLink && (
-                <Tooltip className="radix-themes-custom-fonts" content="View GitHub ">
+                <Tooltip className="radix-themes-custom-fonts" content="View GitHub">
                   <IconButton asChild size="3" variant="ghost" color="gray">
-                    <a href={gitHubLink} target="_blank">
+                    <a href={gitHubLink} target="_blank" aria-label="View GitHub">
                       <GitHubLogoIcon width="16" height="16" />
                     </a>
                   </IconButton>


### PR DESCRIPTION
###Description

Fixes the bug: [radix-ui/website#786](https://github.com/radix-ui/website/issues/786)

This PR fixes a bug where the GitHub link had an empty accessibility name. The change adds an `aria-label` attribute to the link, as "View GitHub".

<img width="336" alt="Screenshot 2024-08-21 at 1 32 18 AM" src="https://github.com/user-attachments/assets/e2a65a13-d7a8-4ef6-9c9a-25ff756b2287">


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug

###Test Link
https://radix-website-git-fork-damyantjain-github-accessibility-workos.vercel.app/
