### PR TITLE
fix animating-content-size docs (Added mention of issues and solutions when using “display: flex”)

### DIFF
--- a/data/primitives/docs/components/accordion/1.2.0.mdx
+++ b/data/primitives/docs/components/accordion/1.2.0.mdx
@@ -558,6 +558,43 @@ export default () => (
 }
 ```
 
+#### Applying Animations in Non-Tailwind CSS Projects
+
+When working with CSS animations outside of Tailwind, it’s important to avoid conflicts with dynamic height calculations, especially in flex layouts. Instead of using height, you can use **max-height** for smoother animations and to prevent double rendering issues. Here’s how you can define the animations using **max-height**:
+
+```css
+/* styles.css */
+.AccordionContent {
+  overflow: hidden;
+}
+.AccordionContent[data-state='open'] {
+  animation: slideDown 300ms ease-out;
+}
+.AccordionContent[data-state='closed'] {
+  animation: slideUp 300ms ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    __max-height__: 0;
+  }
+  to {
+    __max-height__: var(__--radix-accordion-content-height__);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    __max-height__: var(__--radix-accordion-content-height__);
+  }
+  to {
+    __max-height__: 0;
+  }
+}
+```
+
+Using **max-height** ensures that the animation doesn’t conflict with the automatic height calculations performed by flex layouts, leading to smoother transitions without layout recalculation issues.
+
 ## Accessibility
 
 Adheres to the [Accordion WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion).

--- a/data/primitives/docs/components/collapsible/1.1.0.mdx
+++ b/data/primitives/docs/components/collapsible/1.1.0.mdx
@@ -264,6 +264,43 @@ export default () => (
 }
 ```
 
+#### Applying Animations in Non-Tailwind CSS Projects
+
+When working with CSS animations outside of Tailwind, it’s important to avoid conflicts with dynamic height calculations, especially in flex layouts. Instead of using height, you can use **max-height** for smoother animations and to prevent double rendering issues. Here’s how you can define the animations using **max-height**:
+
+```css
+/* styles.css */
+.AccordionContent {
+  overflow: hidden;
+}
+.AccordionContent[data-state='open'] {
+  animation: slideDown 300ms ease-out;
+}
+.AccordionContent[data-state='closed'] {
+  animation: slideUp 300ms ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    __max-height__: 0;
+  }
+  to {
+    __max-height__: var(__--radix-accordion-content-height__);
+  }
+}
+
+@keyframes slideUp {
+  from {
+    __max-height__: var(__--radix-accordion-content-height__);
+  }
+  to {
+    __max-height__: 0;
+  }
+}
+```
+
+Using **max-height** ensures that the animation doesn’t conflict with the automatic height calculations performed by flex layouts, leading to smoother transitions without layout recalculation issues.
+
 ## Accessibility
 
 Adheres to the [Disclosure WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure).


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

---

test url: http://localhost:3000/primitives/docs/components/accordion#animating-content-size
modification: https://github.com/radix-ui/primitives/issues/2832#issuecomment-2327829491
modification-mdx-content:
```mdx
#### Applying Animations in Non-Tailwind CSS Projects

When working with CSS animations outside of Tailwind, it’s important to avoid conflicts with dynamic height calculations, especially in flex layouts. Instead of using height, you can use **max-height** for smoother animations and to prevent double rendering issues. Here’s how you can define the animations using **max-height**:

```css
/* styles.css */
.AccordionContent {
  overflow: hidden;
}
.AccordionContent[data-state='open'] {
  animation: slideDown 300ms ease-out;
}
.AccordionContent[data-state='closed'] {
  animation: slideUp 300ms ease-out;
}

@keyframes slideDown {
  from {
    __max-height__: 0;
  }
  to {
    __max-height__: var(__--radix-accordion-content-height__);
  }
}

@keyframes slideUp {
  from {
    __max-height__: var(__--radix-accordion-content-height__);
  }
  to {
    __max-height__: 0;
  }
}
```

Using **max-height** ensures that the animation doesn’t conflict with the automatic height calculations performed by flex layouts, leading to smoother transitions without layout recalculation issues.

---

This pull request
- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
