### PR TITLE
Swap display order for sun and moon icons in ThemeToggle.tsx

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -15,12 +15,12 @@ export const ThemeToggle = ({
       <Head>
         <style>{`
         :root, .light, .light-theme {
-          --theme-toggle-sun-icon-display: block;
-          --theme-toggle-moon-icon-display: none;
-        }
-        .dark, .dark-theme {
           --theme-toggle-sun-icon-display: none;
           --theme-toggle-moon-icon-display: block;
+        }
+        .dark, .dark-theme {
+          --theme-toggle-sun-icon-display: block;
+          --theme-toggle-moon-icon-display: none;
         }
       `}</style>
       </Head>


### PR DESCRIPTION
The logic here is:
- Display the sun icon when the current theme is dark mode, indicating that clicking the button will switch to light mode.
- Display the moon icon when the current theme is light mode, indicating that clicking the button will switch to dark mode.

Examples I found in the wild:
- https://react.dev/

Sadly most of our favorite websites use tri-state selectors for theming, so not many toggles out there.

---

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR. (Anywhere)

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [x] Other
