### PR TITLE
Fix released Dialog version

### DIFF
--- a/data/primitives/docs/overview/releases.mdx
+++ b/data/primitives/docs/overview/releases.mdx
@@ -87,7 +87,7 @@ Released minor versions for all primitives with the following changes:
 - Make sure that components with roving focus do not interfere with browser or system hotkeys, such as back navigation <PRLink id={2739} />
 - Make sure that components that support `hideWhenDetached` prop do not allow interactions with hidden content <PRLink id={2743} /> <PRLink id={2745} />
 
-<PackageRelease name="Dialog" version="1.2.0" />
+<PackageRelease name="Dialog" version="1.1.0" />
 
 - Log an error when an accessible title via the `Dialog.Title` part is missing <PRLink id={2948} />
 - Log a warning when an accessible description via the `Dialog.Description` part is missing <PRLink id={2948} />


### PR DESCRIPTION
Dialog max version is 1.1.2 so the previous text saying 1.2.0 is incorrect.

Page with typo: https://www.radix-ui.com/primitives/docs/overview/releases#june-19-2024
NPM package published versions: https://www.npmjs.com/package/@radix-ui/react-dialog?activeTab=versions 

Screenshots:
![CleanShot 2024-10-09 at 09 38 35@2x](https://github.com/user-attachments/assets/28afe653-c581-451c-a39c-f4c3ad8b3391)
![CleanShot 2024-10-09 at 09 39 24@2x](https://github.com/user-attachments/assets/db3e35fb-7c23-49b1-b563-6301e8f059a9)


<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other
