### PR TITLE
docs(radio-group): Mention checking in shortcut descriptions

### DIFF
--- a/data/primitives/docs/components/radio-group/1.2.1.mdx
+++ b/data/primitives/docs/components/radio-group/1.2.1.mdx
@@ -305,11 +305,11 @@ Adheres to the [Radio Group WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA
 		},
 		{
 			keys: ["ArrowUp"],
-			description: "Moves focus to the previous radio item in the group.",
+			description: "Moves focus and checks the previous radio item in the group.",
 		},
 		{
 			keys: ["ArrowLeft"],
-			description: "Moves focus to the previous radio item in the group.",
+			description: "Moves focus and checks the previous radio item in the group.",
 		},
 	]}
 />


### PR DESCRIPTION
Based on my testing of the demo on this page, the radio button gets checked when focus moves to it. For some reason, this was only mentioned in the description for "down" and "right", not for "up" and "left". 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [X] Updates documentation or example code
- [ ] Other
