### PR TITLE
docs(reset): fix incorrect link for slot primitive

### DIFF
--- a/data/themes/docs/components/reset.mdx
+++ b/data/themes/docs/components/reset.mdx
@@ -8,7 +8,7 @@ sourcePath: components/reset
 
 Reset component is used to aggressively reset browser styles on a specific element.
 
-It renders a [Slot primitive](/primitives/docs/utilities/portal) that:
+It renders a [Slot primitive](/primitives/docs/utilities/slot) that:
 
 - Accepts a single React element as its child
 - Removes opinionated browser styles


### PR DESCRIPTION
Hi team, Just a small fix to the docs. 
I noticed the link for Slot Primitive in [radix-ui / themes](https://www.radix-ui.com/themes/docs/components/reset) docs was redirecting to Portal Primitive. So I thought why not fix it :)

To replicate this issue in live:
- Go to [radix-ui](https://www.radix-ui.com/themes/docs/components/reset#api-reference) website.
- Click on Slot Primitive anchor text as shown.
  <img src="https://github.com/user-attachments/assets/69524b18-2a62-42f4-970e-ac9b50c95912" alt="Image Reference" width="400">
- It will lead you to Portal Primitive page.

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
