### PR TITLE
docs(IconButton): Add accessibility guidance for aria-labels

### DIFF
--- a/data/themes/docs/components/icon-button.mdx
+++ b/data/themes/docs/components/icon-button.mdx
@@ -18,6 +18,22 @@ This component is based on the `button` element and supports [common margin prop
 
 ## Examples
 
+{
+
+<Callout.Root my="5" color="gray">
+  <Callout.Icon>
+    <InfoCircledIcon />
+  </Callout.Icon>
+  <Callout.Text>
+    It's strongly recommended to include
+    an <Code>aria-label</Code> prop on <Code>IconButton</Code> components since
+    they don't contain visible text.
+    Screen readers rely on this label to announce the button's purpose to users.
+  </Callout.Text>
+</Callout.Root>
+
+}
+
 ### Size
 
 Use the `size` prop to control the size of the button.


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:
- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

This PR adds an accessibility callout to the IconButton component documentation, highlighting the importance of using aria-labels for screen reader support. This documentation update is related to the issue raised in [radix-ui/themes](https://github.com/radix-ui/themes/issues/643)

The change consists of adding a callout section that guides developers on making IconButton components accessible to screen readers by recommending the use of aria-labels.

[Test here](https://radix-website-git-fork-balazsotakomaiya-improve-i-cbdb06-workos.vercel.app/themes/docs/components/icon-button#examples)