### PR TITLE
docs(direction-provider): update Direction Provider example to use a named import

### DIFF
--- a/data/primitives/docs/utilities/direction-provider.mdx
+++ b/data/primitives/docs/utilities/direction-provider.mdx
@@ -25,16 +25,16 @@ npm install @radix-ui/react-direction
 Import the component.
 
 ```jsx
-import { Direction } from "radix-ui";
+import { DirectionProvider } from '@radix-ui/react-direction';
 
-export default () => <Direction.Provider />;
+export default () => <DirectionProvider />;
 ```
 
 ## API Reference
 
 ### Provider
 
-When creating localized apps that require right-to-left (RTL) reading direction, you need to wrap your application with the `Direction.Provider` component to ensure all of the primitives adjust their behavior based on the `dir` prop.
+When creating localized apps that require right-to-left (RTL) reading direction, you need to wrap your application with the `DirectionProvider` component to ensure all of the primitives adjust their behavior based on the `dir` prop.
 
 <PropsTable
 	data={[
@@ -58,9 +58,9 @@ When creating localized apps that require right-to-left (RTL) reading direction,
 Use the direction provider.
 
 ```jsx
-import { Direction } from "radix-ui";
+import { DirectionProvider } from '@radix-ui/react-direction';
 
 export default () => (
-	<Direction.Provider dir="rtl">{/* your app */}</Direction.Provider>
+	<DirectionProvider dir="rtl">{/* your app */}</DirectionProvider>
 );
 ```


### PR DESCRIPTION
This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

Given the [installation instructions](https://www.radix-ui.com/primitives/docs/utilities/direction-provider#installation):
```sh
npm install @radix-ui/react-direction
```

It doesn't make sense to showcase an example importing from the entire Radix UI package.

```tsx
import { Direction } from "radix-ui";
```
