### PR TITLE
docs: slot imported from wrong package name, example not valid

### DIFF
--- a/data/primitives/docs/utilities/slot.mdx
+++ b/data/primitives/docs/utilities/slot.mdx
@@ -23,7 +23,7 @@ npm install @radix-ui/react-slot
 Import the component.
 
 ```jsx
-import { Slot } from "radix-ui";
+import { Slot } from "@radix-ui/react-slot";
 
 export default () => (
 	<Slot.Root>
@@ -41,7 +41,7 @@ When your component has a single children element:
 ```jsx line=9
 // your-button.jsx
 import * as React from "react";
-import { Slot } from "radix-ui";
+import { Slot } from "@radix-ui/react-slot";
 
 function Button({ asChild, ...props }) {
 	const Comp = asChild ? Slot.Root : "button";
@@ -54,7 +54,7 @@ Use `Slottable` when your component has multiple children to pass the props to t
 ```jsx
 // your-button.jsx
 import * as React from "react";
-import { Slot } from "radix-ui";
+import { Slot } from "@radix-ui/react-slot";
 
 function Button({ asChild, children, leftElement, rightElement, ...props }) {
 	const Comp = asChild ? Slot.Root : "button";
@@ -89,16 +89,17 @@ When merging event handlers, `Slot` will create a new function where the child h
 If one of the event handlers relies on `event.defaultPrevented` make sure that the order is correct.
 
 ```jsx
-import { Slot } from "radix-ui";
+import { Slot } from "@radix-ui/react-slot";
 
 export default () => (
-	<Slot.Root
-		onClick={(event) => {
-			if (!event.defaultPrevented)
-				console.log("Not logged because default is prevented.");
-		}}
-	>
-		<button onClick={(event) => event.preventDefault()} />
-	</Slot>
+  <Slot.Root
+    onClick={(event) => {
+      if (!event.defaultPrevented) {
+        console.log("Not logged because default is prevented.");
+      }
+    }}
+  >
+    <button onClick={(event) => event.preventDefault()} />
+  </Slot.Root>
 );
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

I noticed while doing this that a lot of examples are importing from `"radix-ui"`, I can fix everywhere, but I want to make sure it's not intentional first.
