### PR TITLE
fix(Slot): replace Slottable → Slot.Slottable, Root → Slot.Root

### DIFF
--- a/data/primitives/docs/utilities/slot.mdx
+++ b/data/primitives/docs/utilities/slot.mdx
@@ -61,7 +61,7 @@ function Button({ asChild, children, leftElement, rightElement, ...props }) {
 	return (
 		<Comp {...props}>
 			{leftElement}
-			<Slot.Slottable>{children}</Slottable>
+			<Slot.Slottable>{children}</Slot.Slottable>
 			{rightElement}
 		</Comp>
 	);
@@ -99,6 +99,6 @@ export default () => (
 		}}
 	>
 		<button onClick={(event) => event.preventDefault()} />
-	</Slot>
+	</Slot.Root>
 );
 ```


### PR DESCRIPTION
### Summary

This pull request updates the Radix `Slot` usage in documentation and example code:

- Replaces `Root` with `Slot.Root` for clarity and correctness.
- Replaces `Slottable` with `Slot.Slottable` to match the current API.

These changes ensure proper usage of the `radix-ui` Slot API and improve consistency across examples.

### Test Links with Previews

You can verify the updated behavior and syntax at the following official documentation pages:

- [Slot Basic Example](https://www.radix-ui.com/primitives/docs/utilities/slot#basic-example)  
![Screenshot 2025-04-08 at 1 17 51 PM](https://github.com/user-attachments/assets/40c6c7e1-9d05-4a47-849c-c92927863f86)

- [Slot Event Handlers](https://www.radix-ui.com/primitives/docs/utilities/slot#event-handlers)
![Screenshot 2025-04-08 at 1 18 18 PM](https://github.com/user-attachments/assets/53082665-7d16-442d-a1c1-7a10b1cb495c)
 
 ---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

