### PR TITLE
Fixed abrupt overflow on the arrow

### DIFF
--- a/components/demos/Tooltip/tailwind/index.jsx
+++ b/components/demos/Tooltip/tailwind/index.jsx
@@ -17,7 +17,7 @@ const TooltipDemo = () => {
 						sideOffset={5}
 					>
 						Add to library
-						<Tooltip.Arrow className="fill-white" />
+						<Tooltip.Arrow className="fill-white mx-1" />
 					</Tooltip.Content>
 				</Tooltip.Portal>
 			</Tooltip.Root>


### PR DESCRIPTION
Near the edges of the viewport, the arrow "detaches" from the tooltip. Added margin to prevent that.
