### PR TITLE
Fix/composing-a-palette-contrast-color

### DIFF
--- a/components/ColorGrayPairs.tsx
+++ b/components/ColorGrayPairs.tsx
@@ -20,8 +20,6 @@ const pairings = [
 	{ color: "sand", pairs: ["yellow", "amber", "orange", "brown"] },
 ];
 
-const darkTextPair = ["sky", "mint", "lime", "amber", "yellow"];
-
 export function ColorGrayPairs() {
 	return (
 		<Box>
@@ -65,9 +63,7 @@ export function ColorGrayPairs() {
 									as="p"
 									size="2"
 									style={{
-										color: darkTextPair.includes(pair)
-											? `var(--${color}-12)`
-											: "white",
+										color: `var(--${pair}-contrast)`,
 										textTransform: "capitalize",
 									}}
 								>

--- a/components/ColorGrayPairsComplementary.tsx
+++ b/components/ColorGrayPairsComplementary.tsx
@@ -28,6 +28,10 @@ const darkBgColors = ["sky", "mint", "lime", "yellow", "amber"];
 export function ColorGrayPairsComplementary() {
 	return (
 		<Box>
+			<Text as="p" mb="3">
+				Scales designed for white foreground text:
+			</Text>
+
 			<Grid
 				align="center"
 				my="5"

--- a/components/ColorGrayPairsComplementary.tsx
+++ b/components/ColorGrayPairsComplementary.tsx
@@ -77,7 +77,7 @@ export function ColorGrayPairsComplementary() {
 							as="p"
 							size="2"
 							style={{
-								color: `var(--${color}-9-contrast)`,
+								color: `var(--${color}-contrast)`,
 								textTransform: "capitalize",
 							}}
 						>

--- a/data/colors/docs/palette-composition/composing-a-palette.mdx
+++ b/data/colors/docs/palette-composition/composing-a-palette.mdx
@@ -13,8 +13,6 @@ metaDescription: A guide to composing a color palette with Radix Colors.
 
 Radix provides a number of scales you could use for your brand or accent color.
 
-Scales designed for white foreground text:
-
 <ColorGrayPairsComplementary />
 
 ### Custom brand colors


### PR DESCRIPTION
This PR aims to fix a bug in the "Composing a color palette" page:
https://www.radix-ui.com/colors/docs/palette-composition/composing-a-palette

When switching to dark mode, the text colors on the scales that needs dark foreground color turn into bright text

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
