### PR TITLE
fix(docs): Remove duplicate href in HoverCard example (#861)

### DIFF
--- a/data/themes/docs/components/hover-card.mdx
+++ b/data/themes/docs/components/hover-card.mdx
@@ -9,7 +9,7 @@ sourcePath: components/hover-card
 	Follow{" "}
 	<HoverCard.Root>
 		<HoverCard.Trigger>
-			<Link href="#" href="https://twitter.com/radix_ui" target="_blank">
+			<Link href="https://twitter.com/radix_ui" target="_blank">
 				@radix_ui
 			</Link>
 		</HoverCard.Trigger>


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

## Summary

Removes a duplicate `href` attribute from the `<Link>` element in the `HoverCard` documentation example.

**Before:**
```jsx
<Link href="#" href="https://twitter.com/radix_ui" target="_blank">
```

**After**
```jsx
<Link href="https://twitter.com/radix_ui" target="_blank">
```

Related Issue
Closes #861

Test URL
https://www.radix-ui.com/themes/docs/components/hover-card