### PR TITLE
Fix text styling on platte composition page

### DIFF
--- a/components/ColorGrayPairsComplementary.tsx
+++ b/components/ColorGrayPairsComplementary.tsx
@@ -77,7 +77,7 @@ export function ColorGrayPairsComplementary() {
 							as="p"
 							size="2"
 							style={{
-								color: `var(--${color}-9-contrast)`,
+								color: `var(--${color}-contrast)`,
 								textTransform: "capitalize",
 							}}
 						>


### PR DESCRIPTION
The text color for some of the scales is incorrect when using dark mode. This fixes that page to use the correct css variable.

Pre-fix: 
<img width="886" alt="image" src="https://github.com/user-attachments/assets/56f400a5-b645-4448-8cf1-45d560df2f98" />


Post-fix: 
<img width="816" alt="image" src="https://github.com/user-attachments/assets/4c4e743f-7447-4e50-8be8-bc24e7a89fe3" />


This pull request:

- [X] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

URL: https://www.radix-ui.com/colors/docs/palette-composition/composing-a-palette