### PR TITLE
Fix alpha transparent background for other colors

### DIFF
--- a/components/Scale.tsx
+++ b/components/Scale.tsx
@@ -129,7 +129,6 @@ export const ColorScale = ({
 	const isAlpha = name.endsWith("A");
 	const isDarkAlpha = name.endsWith("DarkA");
 	const isWhiteA = name.endsWith("whiteA");
-	const isBlackA = name.endsWith("blackA");
 
 	return (
 		<Flex
@@ -152,33 +151,27 @@ export const ColorScale = ({
 							width="48px"
 							flexShrink="1"
 							style={{
-								backgroundColor: isDarkAlpha
-									? Colors["grayDark"]["gray1"]
-									: isAlpha
-										? "white"
-										: "transparent",
-
-								// Show transparency grid for whiteA and blackA
-								...(isBlackA && {
-									backgroundColor: "white",
-									backgroundSize: "16px 16px",
-									backgroundPosition: "0px 0px, 8px 0px, 8px -8px, 0px 8px",
-									backgroundImage: `
-											linear-gradient(45deg, #f8f8f8 25%, transparent 25%),
-											linear-gradient(135deg, #f8f8f8 25%, transparent 25%),
-											linear-gradient(45deg, transparent 75%, #f8f8f8 75%),
-											linear-gradient(135deg, transparent 75%, #f8f8f8 75%)`,
-								}),
-								...(isWhiteA && {
-									backgroundColor: "#181818",
-									backgroundSize: "16px 16px",
-									backgroundPosition: "0px 0px, 8px 0px, 8px -8px, 0px 8px",
-									backgroundImage: `
-											linear-gradient(45deg, #222222 25%, transparent 25%),
-											linear-gradient(135deg, #222222 25%, transparent 25%),
-											linear-gradient(45deg, transparent 75%, #222222 75%),
-											linear-gradient(135deg, transparent 75%, #222222 75%)`,
-								}),
+								// Show transparency grid for all alpha colors
+								...(isAlpha
+									? {
+											backgroundColor:
+												isWhiteA || isDarkAlpha ? "#181818" : "#ffffff",
+											backgroundSize: "16px 16px",
+											backgroundPosition: "0 0, 8px 0, 8px -8px, 0 8px",
+											backgroundImage:
+												isWhiteA || isDarkAlpha
+													? `
+              linear-gradient(45deg, #222222 25%, transparent 25%),
+              linear-gradient(135deg, #222222 25%, transparent 25%),
+              linear-gradient(45deg, transparent 75%, #222222 75%),
+              linear-gradient(135deg, transparent 75%, #222222 75%)`
+													: `
+              linear-gradient(45deg, #f8f8f8 25%, transparent 25%),
+              linear-gradient(135deg, #f8f8f8 25%, transparent 25%),
+              linear-gradient(45deg, transparent 75%, #f8f8f8 75%),
+              linear-gradient(135deg, transparent 75%, #f8f8f8 75%)`,
+										}
+									: { backgroundColor: "transparent" }),
 							}}
 						>
 							<Box


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug (maybe it was a feature hahaha but couldn't tell the diff between alpha and solid scales)
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other

---

### Summary

Alpha color scales (`blueA`, `redA`, `irisA`, etc.) were previously rendered on solid backgrounds making transparency levels hard to see.  
Only `blackA` and `whiteA` overlays used the grid background pattern that clearly shows transparency.

This change applies the same grid background pattern to all alpha scales for visual consistency:

- **Light alpha scales** (`*A`) → white checkerboard
- **Dark alpha scales** (`*DarkA`) and `whiteA` → dark checkerboard
- Overlay appearance for `blackA` and `whiteA` remains unchanged

---

### Before
<img width="1371" height="333" alt="Screenshot-20250810-181331" src="https://github.com/user-attachments/assets/9e51ead9-b1a0-44fa-962d-0ac367c94c47" />

### After
<img width="1176" height="1002" alt="Screenshot-20250810-181139" src="https://github.com/user-attachments/assets/2027832c-5da3-44a3-a8a8-74336ca5a9e3" />
