### PR TITLE
docs(theme/color): fix typo in Grays section - "compliments" should be "complements"

### DIFF
--- a/data/themes/docs/theme/color.mdx
+++ b/data/themes/docs/theme/color.mdx
@@ -75,7 +75,7 @@ var(--accent-contrast);
 
 ## Grays
 
-You can also choose between a pure gray or a number of tinted grays. Your accent color will be automatically paired with a gray shade that compliments it. However, you can also specify a custom `grayColor` directly on the [Theme](/themes/docs/components/theme) component:
+You can also choose between a pure gray or a number of tinted grays. Your accent color will be automatically paired with a gray shade that complements it. However, you can also specify a custom `grayColor` directly on the [Theme](/themes/docs/components/theme) component:
 
 ```jsx
 <Theme grayColor="mauve">


### PR DESCRIPTION
Fix typo in Theme/Colors/Grays section: "that compliments it" should be"that complements it"

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [ ] Adds additional features/functionality
- [x] Updates documentation or example code
- [ ] Other
