### PR TITLE
fix: prevent React DOM error when using browser translation

### DIFF
--- a/components/marketing/AccessibilitySection.tsx
+++ b/components/marketing/AccessibilitySection.tsx
@@ -645,58 +645,30 @@ export const AccessibilitySection = () => {
 	);
 };
 
+const screenReaderItems: { state: MockDropdownState; label: string; suffix: string; prefix?: string }[] = [
+	{ state: "closed", label: "Navigation,", suffix: "pop-up, button" },
+	{ state: "item1", label: "Show Minimap,", suffix: "menu item", prefix: "ticked, " },
+	{ state: "item2", label: "Go to Symbol,", suffix: "menu item" },
+	{ state: "item3", label: "Go to Definition,", suffix: "menu item" },
+	{ state: "item4", label: "Go to References,", suffix: "menu item" },
+];
+
 const ScreenReaderOutput = ({
 	dropdownState,
 }: {
 	dropdownState: MockDropdownState;
-}) => {
-	if (dropdownState === "closed") {
-		return (
-			<span>
-				Navigation,
+}) => (
+	<>
+		{screenReaderItems.map(({ state, label, suffix, prefix }) => (
+			<span key={state} style={dropdownState !== state ? { display: "none" } : undefined}>
+				{label}
 				<br />
-				menu <span style={{ whiteSpace: "nowrap" }}>pop-up</span>, button
+				{prefix}
+				<span style={{ whiteSpace: "nowrap" }}>{suffix}</span>
 			</span>
-		);
-	}
-	if (dropdownState === "item1") {
-		return (
-			<span>
-				Show Minimap,
-				<br />
-				ticked, <span style={{ whiteSpace: "nowrap" }}>menu item</span>
-			</span>
-		);
-	}
-	if (dropdownState === "item2") {
-		return (
-			<span>
-				Go to Symbol,
-				<br />
-				<span style={{ whiteSpace: "nowrap" }}>menu item</span>
-			</span>
-		);
-	}
-	if (dropdownState === "item3") {
-		return (
-			<span>
-				Go to Definition,
-				<br />
-				<span style={{ whiteSpace: "nowrap" }}>menu item</span>
-			</span>
-		);
-	}
-	if (dropdownState === "item4") {
-		return (
-			<span>
-				Go to References,
-				<br />
-				<span style={{ whiteSpace: "nowrap" }}>menu item</span>
-			</span>
-		);
-	}
-	return null;
-};
+		))}
+	</>
+);
 
 const MockDropdown = ({ state }: { state?: MockDropdownState }) => {
 	return (


### PR DESCRIPTION
## fix: prevent React DOM error when browser translation modifies ScreenReaderOutput

- Render all screen reader text items simultaneously with CSS display toggle
- Prevents 'removeChild' error caused by browser translation modifying DOM
- Refactored to use data array for cleaner, more maintainable code

<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

---

Fixes #896

## Problem

When using browser translation on `/primitives` and scrolling to the "Accessibility out of the box" section, the following error occurs:

> Uncaught NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.

This happens because browser translation modifies the DOM structure, and when React tries to conditionally render different `<span>` elements in `ScreenReaderOutput`, it conflicts with the translated DOM.

## Solution

Instead of conditionally rendering different elements based on `dropdownState`, render all text items simultaneously and control visibility with CSS `display: none`. This prevents React from adding or removing DOM nodes, avoiding conflicts with browser translation.

## Testing

1. Run `pnpm dev`
2. Navigate to `http://localhost:3000/primitives`
3. Enable browser translation
4. Scroll to "Accessibility out of the box" section
5. Verify no console errors appear as the animation cycles