### PR TITLE
fix(primitives): use CSS variable for demo component background color

### DIFF
--- a/components/demos/ScrollArea/css-modules/styles.module.css
+++ b/components/demos/ScrollArea/css-modules/styles.module.css
@@ -4,7 +4,7 @@
 	border-radius: 4px;
 	overflow: hidden;
 	box-shadow: 0 2px 10px var(--black-a4);
-	background-color: white;
+	background-color: var(--color-background);
 	--scrollbar-size: 10px;
 }
 

--- a/components/demos/ScrollArea/css/styles.css
+++ b/components/demos/ScrollArea/css/styles.css
@@ -8,7 +8,7 @@
 	border-radius: 4px;
 	overflow: hidden;
 	box-shadow: 0 2px 10px var(--black-a4);
-	background-color: white;
+	background-color: var(--color-background);
 	--scrollbar-size: 10px;
 }
 

--- a/components/demos/Tooltip/css-modules/styles.module.css
+++ b/components/demos/Tooltip/css-modules/styles.module.css
@@ -4,7 +4,7 @@
 	font-size: 15px;
 	line-height: 1;
 	color: var(--violet-11);
-	background-color: white;
+	background-color: var(--color-background);
 	box-shadow:
 		hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
 		hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
@@ -40,7 +40,7 @@
 	align-items: center;
 	justify-content: center;
 	color: var(--violet-11);
-	background-color: white;
+	background-color: var(--color-background);
 	box-shadow: 0 2px 10px var(--black-a7);
 	user-select: none;
 	&:hover {

--- a/components/demos/Tooltip/css/styles.css
+++ b/components/demos/Tooltip/css/styles.css
@@ -12,7 +12,7 @@ button {
 	font-size: 15px;
 	line-height: 1;
 	color: var(--violet-11);
-	background-color: white;
+	background-color: var(--color-background);
 	box-shadow:
 		hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
 		hsl(206 22% 7% / 20%) 0px 10px 20px -15px;


### PR DESCRIPTION
<!-- Thank you for contributing! Please fill in this template before submitting your PR to help us process your request more quickly. -->

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [x] Include the URL where we can test the change in the body of your PR.

This pull request:

- [x] Fixes a bug
- [ ] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

## Summary

Demo components (ScrollArea, Tooltip) had hardcoded `background-color: white` which doesn't adapt to dark mode. This PR replaces them with `var(--color-background)` CSS variable to support both light and dark themes.

Related to #851 

## Screenshots

| Before (Dark mode) | After (Dark mode) |
|--------------------|-------------------|
| ![before-scrollarea](https://github.com/user-attachments/assets/ceab2370-faab-44ac-9116-d10d40f4b3c8) | ![after-scrollarea](https://github.com/user-attachments/assets/f31b5efe-c99e-4065-8898-b74559c0bba3) |
| ![before-tooltip](https://github.com/user-attachments/assets/64ee7c9b-9973-4031-9ec5-d736172fe40b) | ![after-tooltip](https://github.com/user-attachments/assets/0c072942-86ae-4138-b2b6-0d01db736e13) |

## Changes

- `components/demos/ScrollArea/css/styles.css` - Updated background-color to use CSS variable
- `components/demos/ScrollArea/css-modules/styles.module.css` - Updated background-color to use CSS variable
- `components/demos/Tooltip/css/styles.css` - Updated background-color to use CSS variable
- `components/demos/Tooltip/css-modules/styles.module.css` - Updated background-color to use CSS variable

## Test URLs

- ScrollArea: http://localhost:3000/primitives/docs/components/scroll-area
- Tooltip: http://localhost:3000/primitives/docs/components/tooltip

(Test in dark mode to verify background colors adapt to the theme)