### PR TITLE
feat(colors): enable dialog close button on all viewports

### DIFF
--- a/components/CustomSwatch.tsx
+++ b/components/CustomSwatch.tsx
@@ -247,13 +247,7 @@ export const CustomSwatch = ({
 								return otherTheme;
 							})()}
 						>
-							<Box
-								position="absolute"
-								m="2"
-								top="0"
-								right="0"
-								display={{ sm: "none" }}
-							>
+							<Box position="absolute" m="2" top="0" right="0">
 								<Dialog.Close>
 									<IconButton size="1" highContrast variant="ghost">
 										<Cross2Icon width="24" height="24" />

--- a/components/Swatch.tsx
+++ b/components/Swatch.tsx
@@ -450,13 +450,7 @@ export const Swatch = ({ scale, step, style, ...props }: SwatchProps) => {
 								return otherTheme;
 							})()}
 						>
-							<Box
-								position="absolute"
-								m="2"
-								top="0"
-								right="0"
-								display={{ sm: "none" }}
-							>
+							<Box position="absolute" m="2" top="0" right="0">
 								<Dialog.Close>
 									<IconButton size="1" highContrast variant="ghost">
 										<Cross2Icon width="24" height="24" />

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://context7.com/radix-ui/website",
-  "public_key": "pk_q7NnKuFFXMWA7WnmjMHQU"
+	"url": "https://context7.com/radix-ui/website",
+	"public_key": "pk_q7NnKuFFXMWA7WnmjMHQU"
 }


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code.
- [ ] Include the URL where we can test the change in the body of your PR.

This pull request:

- [ ] Fixes a bug
- [x] Adds additional features/functionality
- [ ] Updates documentation or example code
- [ ] Other

### Description
The Swatch info dialog (`Dialog.Content`) had its close button hidden on larger screens (`display={{ sm: 'none' }}`), meaning desktop users lacked an obvious exit action. This PR simply removes the breakpoint to ensure the close button is uniformly explicitly visible on all viewports.
### 🟥 Before
<img width="600" src="https://github.com/user-attachments/assets/311237a7-dadd-49c3-bd29-166956817175" />

### 🟩 After
<img width="600" src="https://github.com/user-attachments/assets/f73283de-821e-4682-b971-ef423bf50fbd" />

